### PR TITLE
Fix: App crash by migrate to glide compose

### DIFF
--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.bundles.compose)
-    implementation(libs.github.skydoves.landscapist.glide)
     implementation(libs.androidx.appcompat)
     implementation(libs.google.android.material)
 

--- a/feature/videopicker/build.gradle.kts
+++ b/feature/videopicker/build.gradle.kts
@@ -18,9 +18,9 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.bundles.compose)
-    implementation(libs.github.skydoves.landscapist.glide)
     implementation(libs.androidx.appcompat)
     implementation(libs.google.android.material)
+    implementation(libs.glide.compose)
 
     implementation(libs.androidx.hilt.navigation.compose)
 

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/VideoItemView.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/VideoItemView.kt
@@ -22,14 +22,14 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.skydoves.landscapist.ImageOptions
-import com.skydoves.landscapist.glide.GlideImage
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
 import dev.anilbeesetti.nextplayer.core.common.Utils
 import dev.anilbeesetti.nextplayer.core.data.models.Video
 import dev.anilbeesetti.nextplayer.core.ui.DayNightPreview
 import dev.anilbeesetti.nextplayer.core.ui.theme.NextPlayerTheme
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalGlideComposeApi::class)
 @Composable
 fun VideoItemView(
     video: Video,
@@ -60,11 +60,10 @@ fun VideoItemView(
                 content = {
                     if (video.uriString.isNotEmpty()) {
                         GlideImage(
-                            imageModel = { video.uriString },
-                            imageOptions = ImageOptions(
-                                contentScale = ContentScale.Crop,
-                                alignment = Alignment.Center
-                            )
+                            model = video.uriString,
+                            contentDescription = "Video thumbnail",
+                            alignment = Alignment.Center,
+                            contentScale = ContentScale.Crop
                         )
                     }
                 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ kotlin = "1.8.10"
 kotlinxCoroutines = "1.6.4"
 kotlinxSerializationJson = "1.5.0"
 ktlint = "11.3.1"
-landscapist = "2.1.5"
+glide = "1.0.0-alpha.1"
 room = "2.5.0"
 timber = "5.0.1"
 
@@ -58,7 +58,7 @@ androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = 
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }
 androidx-test-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidxTestExt" }
-github-skydoves-landscapist-glide = { group = "com.github.skydoves", name = "landscapist-glide", version.ref = "landscapist"}
+glide-compose = { group = "com.github.bumptech.glide", name = "compose", version.ref = "glide"}
 google-android-material = { group = "com.google.android.material", name = "material", version.ref = "androidMaterial"}
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }


### PR DESCRIPTION
Landscapist has problem with recycling bitmap. so migrate to glide compose which is currently in alpha
```
java.lang.runtimeexception: canvas: trying to use a recycled bitmap android.graphics.bitmap@96a1c5c
```