### PR TITLE
Fix: App crash by downgrade landscapist to 2.1.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ kotlin = "1.8.10"
 kotlinxCoroutines = "1.6.4"
 kotlinxSerializationJson = "1.5.0"
 ktlint = "11.3.1"
-landscapist = "2.1.5"
+landscapist = "2.1.4"
 room = "2.5.0"
 timber = "5.0.1"
 


### PR DESCRIPTION
Landscapist 2.1.5 has problem with recycled bitmaps which causes app to crash. see this [issue](https://github.com/skydoves/landscapist/issues/233) for more info