### PR TITLE
Chore: Downgrade ndk to 23.1.7779620

### DIFF
--- a/nextlib/ffcodecs/build.gradle.kts
+++ b/nextlib/ffcodecs/build.gradle.kts
@@ -20,7 +20,7 @@ android {
             abiFilters += listOf("x86", "x86_64", "armeabi-v7a", "arm64-v8a")
         }
 
-        ndkVersion = "25.1.8937393"
+        ndkVersion = "23.1.7779620"
     }
 
     externalNativeBuild {


### PR DESCRIPTION
- ffmpeg won't build with current ndk version