### PR TITLE
Fix: Exclude dependencies info from generated apks and bundle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,6 +71,13 @@ android {
             excludes.add("/META-INF/{AL2.0,LGPL2.1}")
         }
     }
+
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
 }
 
 dependencies {


### PR DESCRIPTION
- fixes #1188 