### PR TITLE
feat(Manifest): base ATV support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
         </activity>
     </application>


### PR DESCRIPTION
Refs #322

I try last stable version([v0.12.3](https://github.com/anilbeesetti/nextplayer/releases/tag/v0.12.3)), on my old ATV 11 works great, but no icon in menu.

Links:  
https://developer.android.com/training/tv/get-started/create#tv-activity
https://developer.android.com/guide/components/intents-filters#CategoryTest