### PR TITLE
Add the ass file MIME that the SAF considers

### DIFF
--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerActivity.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerActivity.kt
@@ -581,6 +581,7 @@ class PlayerActivity : AppCompatActivity() {
                             MimeTypes.TEXT_SSA,
                             MimeTypes.BASE_TYPE_APPLICATION + "/octet-stream",
                             MimeTypes.BASE_TYPE_TEXT + "/*",
+                            MimeTypes.BASE_TYPE_AUDIO + "/aac", // .ass
                         ),
                     )
                 },


### PR DESCRIPTION
Unfortunately, the Android system considers ass files to be audio, so SAF cannot select them.


```
Additional information:

   Deprecated alias names for this type: N/A
   Magic number(s): N/A 
   File extension(s): .adts or .aac (ADTS), .loas or .ass (LATM/LOAS)
   Macintosh file type code(s): N/A
```
https://www.iana.org/assignments/media-types/audio/aac