### PR TITLE
Added a new settings section to hide buttons in player and crash fixes

### DIFF
--- a/app/src/main/java/dev/anilbeesetti/nextplayer/MainActivity.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/MainActivity.kt
@@ -83,14 +83,14 @@ class MainActivity : ComponentActivity() {
                 ) {
                     val storagePermissionState = rememberPermissionState(permission = storagePermission)
 
-                    LifecycleEventEffect(event = Lifecycle.Event.ON_START) {
-                        storagePermissionState.launchPermissionRequest()
+                    if (storagePermissionState.status.isGranted) {
+                        synchronizer.startSync()
+                    } else {
+                        synchronizer.stopSync()
                     }
 
-                    LaunchedEffect(key1 = storagePermissionState.status.isGranted) {
-                        if (storagePermissionState.status.isGranted) {
-                            synchronizer.startSync()
-                        }
+                    LifecycleEventEffect(event = Lifecycle.Event.ON_START) {
+                        storagePermissionState.launchPermissionRequest()
                     }
 
                     val mainNavController = rememberNavController()

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,0 +1,6 @@
+fix: Handle media synchronization on permission change
+
+This commit fixes a bug where the app would crash if the storage permission was revoked while the media synchronizer was running.
+
+- The `LocalMediaSynchronizer` is updated to properly stop and restart.
+- The `MainActivity` now manages the synchronizer's lifecycle based on the permission status.

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/sync/LocalMediaSynchronizer.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/sync/LocalMediaSynchronizer.kt
@@ -62,6 +62,7 @@ class LocalMediaSynchronizer @Inject constructor(
 
     override fun stopSync() {
         mediaSyncingJob?.cancel()
+        mediaSyncingJob = null
     }
 
     private suspend fun updateDirectories(media: List<MediaVideo>) =

--- a/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/PlayerPreferences.kt
+++ b/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/PlayerPreferences.kt
@@ -48,4 +48,11 @@ data class PlayerPreferences(
 
     // Decoder Preferences
     val decoderPriority: DecoderPriority = DecoderPriority.PREFER_DEVICE,
+
+    // Player buttons
+    val showLockControlsButton: Boolean = true,
+    val showVideoZoomButton: Boolean = true,
+    val showPipButton: Boolean = true,
+    val showBackgroundPlayButton: Boolean = true,
+    val showScreenRotationButton: Boolean = true,
 )

--- a/core/ui/src/main/java/dev/anilbeesetti/nextplayer/core/ui/designsystem/NextIcons.kt
+++ b/core/ui/src/main/java/dev/anilbeesetti/nextplayer/core/ui/designsystem/NextIcons.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.rounded.Headset
 import androidx.compose.material.icons.rounded.HeadsetOff
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.Link
+import androidx.compose.material.icons.rounded.Lock
 import androidx.compose.material.icons.rounded.LocalMovies
 import androidx.compose.material.icons.rounded.LocationOn
 import androidx.compose.material.icons.rounded.Movie
@@ -96,6 +97,7 @@ object NextIcons {
     val Language = Icons.Rounded.Translate
     val Length = Icons.Rounded.Straighten
     val Link = Icons.Rounded.Link
+    val Lock = Icons.Rounded.Lock
     val Location = Icons.Rounded.LocationOn
     val Movie = Icons.Rounded.LocalMovies
     val Pip = Icons.Rounded.PictureInPictureAlt

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -229,4 +229,10 @@
     <string name="media_layout">Media Layout</string>
     <string name="list">List</string>
     <string name="grid">Grid</string>
+    <string name="buttons">Buttons</string>
+    <string name="show_or_hide_the_lock_controls_button">Show or hide the lock controls button</string>
+    <string name="show_or_hide_the_video_zoom_button">Show or hide the video zoom button</string>
+    <string name="show_or_hide_the_pip_button">Show or hide the picture in picture button</string>
+    <string name="show_or_hide_the_background_play_button">Show or hide the background play button</string>
+    <string name="show_or_hide_the_screen_rotation_button">Show or hide the screen rotation button</string>
 </resources>

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerActivity.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerActivity.kt
@@ -253,13 +253,21 @@ class PlayerActivity : AppCompatActivity() {
         loopModeButton = binding.playerView.findViewById(R.id.btn_loop_mode)
         extraControls = binding.playerView.findViewById(R.id.extra_controls)
 
-        if (playerPreferences.controlButtonsPosition == ControlButtonsPosition.RIGHT) {
-            extraControls.gravity = Gravity.END
-        }
+        extraControls.visibility = if (playerPreferences.showLockControlsButton || playerPreferences.showVideoZoomButton || playerPreferences.showPipButton || playerPreferences.showBackgroundPlayButton) View.VISIBLE else View.GONE
+            lockControlsButton.visibility = if (playerPreferences.showLockControlsButton) View.VISIBLE else View.GONE
+            videoZoomButton.visibility = if (playerPreferences.showVideoZoomButton) View.VISIBLE else View.GONE
+            pipButton.visibility = if (playerPreferences.showPipButton && isPipSupported) View.VISIBLE else View.GONE
+            playInBackgroundButton.visibility = if (playerPreferences.showBackgroundPlayButton) View.VISIBLE else View.GONE
 
-        if (!isPipSupported) {
-            pipButton.visibility = View.GONE
-        }
+            if (playerPreferences.controlButtonsPosition == ControlButtonsPosition.RIGHT) {
+                extraControls.gravity = Gravity.END
+            }
+
+            if (!isPipSupported) {
+                pipButton.visibility = View.GONE
+            }
+
+            screenRotateButton.visibility = if (playerPreferences.showScreenRotationButton) View.VISIBLE else View.GONE
 
         seekBar.addListener(
             object : TimeBar.OnScrubListener {

--- a/feature/player/src/main/res/layout/exo_player_control_view.xml
+++ b/feature/player/src/main/res/layout/exo_player_control_view.xml
@@ -162,6 +162,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:contentDescription="@string/player_controls_progress"
+                    android:layout_marginBottom="8dp"
                     app:layout_constraintBottom_toTopOf="@id/extra_controls"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"

--- a/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/player/PlayerPreferencesScreen.kt
+++ b/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/player/PlayerPreferencesScreen.kt
@@ -167,6 +167,28 @@ fun PlayerPreferencesScreen(
                     viewModel.showDialog(PlayerPreferenceDialog.PlayerScreenOrientationDialog)
                 },
             )
+
+            PreferenceSubtitle(text = stringResource(id = R.string.buttons))
+            LockControlsButtonSetting(
+                isChecked = preferences.showLockControlsButton,
+                onClick = viewModel::toggleShowLockControlsButton,
+            )
+            VideoZoomButtonSetting(
+                isChecked = preferences.showVideoZoomButton,
+                onClick = viewModel::toggleShowVideoZoomButton,
+            )
+            PipButtonSetting(
+                isChecked = preferences.showPipButton,
+                onClick = viewModel::toggleShowPipButton,
+            )
+            BackgroundPlayButtonSetting(
+                isChecked = preferences.showBackgroundPlayButton,
+                onClick = viewModel::toggleShowBackgroundPlayButton,
+            )
+            ScreenRotationButtonSetting(
+                isChecked = preferences.showScreenRotationButton,
+                onClick = viewModel::toggleShowScreenRotationButton,
+            )
         }
 
         uiState.showDialog?.let { showDialog ->
@@ -626,6 +648,76 @@ fun ControlButtonsPositionSetting(
         title = stringResource(id = R.string.control_buttons_alignment),
         description = currentControlButtonPosition.name(),
         icon = NextIcons.ButtonsPosition,
+        onClick = onClick,
+    )
+}
+
+@Composable
+fun LockControlsButtonSetting(
+    isChecked: Boolean,
+    onClick: () -> Unit,
+) {
+    PreferenceSwitch(
+        title = stringResource(R.string.controls_lock),
+        description = stringResource(R.string.show_or_hide_the_lock_controls_button),
+        icon = NextIcons.Lock,
+        isChecked = isChecked,
+        onClick = onClick,
+    )
+}
+
+@Composable
+fun VideoZoomButtonSetting(
+    isChecked: Boolean,
+    onClick: () -> Unit,
+) {
+    PreferenceSwitch(
+        title = stringResource(R.string.video_zoom),
+        description = stringResource(R.string.show_or_hide_the_video_zoom_button),
+        icon = NextIcons.Pinch,
+        isChecked = isChecked,
+        onClick = onClick,
+    )
+}
+
+@Composable
+fun PipButtonSetting(
+    isChecked: Boolean,
+    onClick: () -> Unit,
+) {
+    PreferenceSwitch(
+        title = stringResource(R.string.pip_settings),
+        description = stringResource(R.string.show_or_hide_the_pip_button),
+        icon = NextIcons.Pip,
+        isChecked = isChecked,
+        onClick = onClick,
+    )
+}
+
+@Composable
+fun BackgroundPlayButtonSetting(
+    isChecked: Boolean,
+    onClick: () -> Unit,
+) {
+    PreferenceSwitch(
+        title = stringResource(R.string.background_play),
+        description = stringResource(R.string.show_or_hide_the_background_play_button),
+        icon = NextIcons.Background,
+        isChecked = isChecked,
+        onClick = onClick,
+    )
+}
+
+@Composable
+fun ScreenRotationButtonSetting(
+    isChecked: Boolean,
+    onClick: () -> Unit,
+) {
+    PreferenceSwitch(
+        title = stringResource(R.string.screen_rotation),
+        description = stringResource(R.string.show_or_hide_the_screen_rotation_button),
+        icon = NextIcons.Rotation,
+        isChecked = isChecked,
         onClick = onClick,
     )
 }

--- a/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/player/PlayerPreferencesViewModel.kt
+++ b/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/player/PlayerPreferencesViewModel.kt
@@ -207,6 +207,46 @@ class PlayerPreferencesViewModel @Inject constructor(
             }
         }
     }
+
+    fun toggleShowLockControlsButton() {
+        viewModelScope.launch {
+            preferencesRepository.updatePlayerPreferences {
+                it.copy(showLockControlsButton = !it.showLockControlsButton)
+            }
+        }
+    }
+
+    fun toggleShowVideoZoomButton() {
+        viewModelScope.launch {
+            preferencesRepository.updatePlayerPreferences {
+                it.copy(showVideoZoomButton = !it.showVideoZoomButton)
+            }
+        }
+    }
+
+    fun toggleShowPipButton() {
+        viewModelScope.launch {
+            preferencesRepository.updatePlayerPreferences {
+                it.copy(showPipButton = !it.showPipButton)
+            }
+        }
+    }
+
+    fun toggleShowBackgroundPlayButton() {
+        viewModelScope.launch {
+            preferencesRepository.updatePlayerPreferences {
+                it.copy(showBackgroundPlayButton = !it.showBackgroundPlayButton)
+            }
+        }
+    }
+
+    fun toggleShowScreenRotationButton() {
+        viewModelScope.launch {
+            preferencesRepository.updatePlayerPreferences {
+                it.copy(showScreenRotationButton = !it.showScreenRotationButton)
+            }
+        }
+    }
 }
 
 data class PlayerPreferencesUIState(


### PR DESCRIPTION
1. Feature: Player Button Customization
I added a new "Buttons" section in the player settings so you can customize which control buttons show up in the player UI.

What you can do now:
Toggle individual buttons:

Bottom-left: Lock, Zoom, Picture-in-Picture (PiP), and Background Play.

Top-right: Screen Rotation toggle.

Adaptive layout:
If you hide all the bottom-left buttons, the layout adjusts automatically — the progress bar and time indicators shift down to keep everything looking neat and clean.

2. Bug Fix: Media Sync & Permission Handling
I fixed a crash that happened when storage permission was revoked after being granted.

The issue:
The media sync process didn’t know how to handle the permission being taken away mid-session, and that caused the app to crash.

Also, once the sync was stopped (like after a permission change), it couldn’t restart properly.

The fix:
I made the synchronizer more robust so it can stop and restart cleanly.

The main screen now checks permission status properly — it starts syncing only when permission is granted and stops immediately when it’s not. No more crashes.

Overall, the app should now handle permission changes smoothly and stay stable no matter what.