### PR TITLE
fix: Not showing error dialog properly (#1391)

### DIFF
--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerActivity.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerActivity.kt
@@ -832,9 +832,13 @@ class PlayerActivity : AppCompatActivity() {
         override fun onPlaybackStateChanged(playbackState: Int) {
             super.onPlaybackStateChanged(playbackState)
             when (playbackState) {
-                Player.STATE_ENDED, Player.STATE_IDLE -> {
+                Player.STATE_ENDED -> {
                     isPlaybackFinished = mediaController?.playbackState == Player.STATE_ENDED
                     finish()
+                }
+
+                Player.STATE_IDLE -> {
+                    isPlaybackFinished = mediaController?.playbackState == Player.STATE_ENDED
                 }
 
                 Player.STATE_READY -> {


### PR DESCRIPTION
### Commit Message
Separated Player.STATE_IDLE & Player.STATE_ENDED so that the activity will not be finished and the dialog will remain in case of an error, which results in Player.STATE_IDLE.

### Issue in Code
As the case branch for `Player.STATE_IDLE` & `Player.STATE_ENDED` were merged, the activity was being finished in the case of any playback error, while the dialog was showing. So separated the `Player.STATE_IDLE` branch so that the activity will not finish and will show the error dialog properly.

### Additional Note
I was not able to reproduce the exact issue mentioned in the issue tracker; however, this will be the case for any type of player error.