### PR TITLE
feat: Added support for Tabletop (Flex Mode/Half Open) in Player [#1313]

### DIFF
--- a/feature/player/build.gradle.kts
+++ b/feature/player/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewModel.ktx)
     implementation(libs.google.android.material)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.window)
 
     // Media3
     implementation(libs.androidx.media3.common)

--- a/feature/player/src/main/res/layout/activity_player.xml
+++ b/feature/player/src/main/res/layout/activity_player.xml
@@ -1,166 +1,176 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".PlayerActivity">
 
-    <LinearLayout
-        android:id="@+id/top_info_layout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="16dp"
-        android:background="@drawable/overlay_background"
-        android:elevation="4dp"
-        android:gravity="center"
-        android:orientation="horizontal"
-        android:padding="5dp"
-        android:visibility="gone">
+    <FrameLayout
+        android:id="@+id/playerViewContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintHeight_percent="1.0"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
-        <ImageView
-            android:id="@+id/fast_speed_image"
+        <LinearLayout
+            android:id="@+id/top_info_layout"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_fast"
-            tools:ignore="ContentDescription" />
-
-        <TextView
-            android:id="@+id/top_info_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/fast_playback_speed"
-            tools:text="hello"
-            android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
-            android:textColor="@android:color/white" />
-    </LinearLayout>
-
-    <androidx.media3.ui.PlayerView
-        android:id="@+id/player_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@android:color/black"
-        app:animation_enabled="false"
-        app:show_buffering="always"
-        tools:foreground="@color/player_background" />
-
-    <LinearLayout
-        android:id="@+id/info_layout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:clickable="false"
-        android:gravity="center_horizontal"
-        android:orientation="vertical"
-        android:visibility="gone"
-        android:layout_marginBottom="84dp"
-        tools:visibility="visible">
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/info_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:shadowColor="@color/player_background"
-            android:shadowDx="1"
-            android:shadowDy="1"
-            android:shadowRadius="2"
-            android:textAppearance="@style/TextAppearance.Material3.DisplaySmall"
-            android:textColor="@android:color/white"
-            android:textStyle="bold"
-            tools:text="22:30" />
-
-        <com.google.android.material.textview.MaterialTextView
-            android:id="@+id/info_subtext"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:shadowColor="@color/player_background"
-            android:shadowDx="1"
-            android:shadowDy="1"
-            android:shadowRadius="2"
-            android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
-            android:textColor="@android:color/white"
-            android:textStyle="bold"
-            tools:text="22:30" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/volume_gesture_layout"
-        android:layout_width="54dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical|start"
-        android:layout_margin="16dp"
-        android:background="@drawable/overlay_background"
-        android:clickable="false"
-        android:gravity="center_horizontal"
-        android:orientation="vertical"
-        android:visibility="gone"
-        tools:visibility="visible">
-
-        <TextView
-            android:id="@+id/volume_progress_text"
-            android:layout_width="wrap_content"
-            android:layout_height="24dp"
-            android:layout_marginVertical="16dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="16dp"
+            android:background="@drawable/overlay_background"
+            android:elevation="4dp"
             android:gravity="center"
-            android:textColor="@android:color/white"
-            tools:text="58%" />
+            android:orientation="horizontal"
+            android:padding="5dp"
+            android:visibility="gone">
 
-        <ProgressBar
-            android:id="@+id/volume_progress_bar"
-            style="?android:attr/progressBarStyleHorizontal"
-            android:layout_width="6dp"
-            android:layout_height="125dp"
-            android:progressDrawable="@drawable/progress_scale_drawable"
-            tools:progress="58" />
+            <ImageView
+                android:id="@+id/fast_speed_image"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_fast"
+                tools:ignore="ContentDescription" />
 
-        <ImageView
-            android:id="@+id/volume_image"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginVertical="16dp"
-            android:src="@drawable/ic_volume"
-            tools:ignore="ContentDescription" />
-    </LinearLayout>
+            <TextView
+                android:id="@+id/top_info_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/fast_playback_speed"
+                tools:text="hello"
+                android:textAppearance="@style/TextAppearance.Material3.TitleSmall"
+                android:textColor="@android:color/white" />
+        </LinearLayout>
 
-    <LinearLayout
-        android:id="@+id/brightness_gesture_layout"
-        android:layout_width="54dp"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical|end"
-        android:layout_margin="16dp"
-        android:background="@drawable/overlay_background"
-        android:clickable="false"
-        android:gravity="center_horizontal"
-        android:orientation="vertical"
-        android:visibility="gone"
-        tools:visibility="visible">
+        <androidx.media3.ui.PlayerView
+            android:id="@+id/player_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@android:color/black"
+            app:animation_enabled="false"
+            app:show_buffering="always"
+            tools:foreground="@color/player_background" />
 
-        <TextView
-            android:id="@+id/brightness_progress_text"
+        <LinearLayout
+            android:id="@+id/info_layout"
             android:layout_width="wrap_content"
-            android:layout_height="24dp"
-            android:layout_marginVertical="16dp"
-            android:gravity="center"
-            android:textColor="@android:color/white"
-            tools:text="58%" />
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:clickable="false"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:visibility="gone"
+            android:layout_marginBottom="84dp"
+            tools:visibility="visible">
 
-        <ProgressBar
-            android:id="@+id/brightness_progress_bar"
-            style="?android:attr/progressBarStyleHorizontal"
-            android:layout_width="6dp"
-            android:layout_height="125dp"
-            android:progressDrawable="@drawable/progress_scale_drawable"
-            tools:progress="58" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/info_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:shadowColor="@color/player_background"
+                android:shadowDx="1"
+                android:shadowDy="1"
+                android:shadowRadius="2"
+                android:textAppearance="@style/TextAppearance.Material3.DisplaySmall"
+                android:textColor="@android:color/white"
+                android:textStyle="bold"
+                tools:text="22:30" />
 
-        <ImageView
-            android:id="@+id/brightness_icon"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginVertical="16dp"
-            android:src="@drawable/ic_brightness"
-            tools:ignore="ContentDescription" />
-    </LinearLayout>
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/info_subtext"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:shadowColor="@color/player_background"
+                android:shadowDx="1"
+                android:shadowDy="1"
+                android:shadowRadius="2"
+                android:textAppearance="@style/TextAppearance.Material3.HeadlineMedium"
+                android:textColor="@android:color/white"
+                android:textStyle="bold"
+                tools:text="22:30" />
 
-</FrameLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/volume_gesture_layout"
+            android:layout_width="54dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical|start"
+            android:layout_margin="16dp"
+            android:background="@drawable/overlay_background"
+            android:clickable="false"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:id="@+id/volume_progress_text"
+                android:layout_width="wrap_content"
+                android:layout_height="24dp"
+                android:layout_marginVertical="16dp"
+                android:gravity="center"
+                android:textColor="@android:color/white"
+                tools:text="58%" />
+
+            <ProgressBar
+                android:id="@+id/volume_progress_bar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="6dp"
+                android:layout_height="125dp"
+                android:progressDrawable="@drawable/progress_scale_drawable"
+                tools:progress="58" />
+
+            <ImageView
+                android:id="@+id/volume_image"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginVertical="16dp"
+                android:src="@drawable/ic_volume"
+                tools:ignore="ContentDescription" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/brightness_gesture_layout"
+            android:layout_width="54dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical|end"
+            android:layout_margin="16dp"
+            android:background="@drawable/overlay_background"
+            android:clickable="false"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:id="@+id/brightness_progress_text"
+                android:layout_width="wrap_content"
+                android:layout_height="24dp"
+                android:layout_marginVertical="16dp"
+                android:gravity="center"
+                android:textColor="@android:color/white"
+                tools:text="58%" />
+
+            <ProgressBar
+                android:id="@+id/brightness_progress_bar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="6dp"
+                android:layout_height="125dp"
+                android:progressDrawable="@drawable/progress_scale_drawable"
+                tools:progress="58" />
+
+            <ImageView
+                android:id="@+id/brightness_icon"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginVertical="16dp"
+                android:src="@drawable/ic_brightness"
+                tools:ignore="ContentDescription" />
+        </LinearLayout>
+
+    </FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ room = "2.7.2"
 nextlib = "1.8.0-0.9.0"
 timber = "5.0.1"
 universalChardet = "2.5.0"
+window = "1.4.0"
 
 
 [libraries]
@@ -71,6 +72,7 @@ androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = 
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }
 androidx-test-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidxTestExt" }
+androidx-window = { module = "androidx.window:window", version.ref = "window" }
 coil-kt-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 github-albfernandez-juniversalchardet = { group="com.github.albfernandez", name = "juniversalchardet", version.ref="universalChardet" }
 github-anilbeesetti-nextlib-media3ext = { group = "io.github.anilbeesetti", name = "nextlib-media3ext", version.ref = "nextlib" }


### PR DESCRIPTION
### Commit Message
- Added Jetpack WindowManager dependency
- Changed Player Activity & Layout to support Tabletop

### Feature Overview
In the player page, when the device goes to Tabletop/Flex Mode/Half Open, the player screen will only occupy the top half of the screen.

This can be achieved by implementing fold-aware logic in the activity.

[https://developer.android.com/develop/ui/compose/layouts/adaptive/foldables/make-your-app-fold-aware#tabletop_posture](https://developer.android.com/develop/ui/compose/layouts/adaptive/foldables/make-your-app-fold-aware#tabletop_posture)

### Code Changes
Added WindowManager dependency in the `player` module. In the `activity_player.xml`, the root view is moved inside a constraint layout so that it can be managed easily to fill the top half of the screen by setting the `layout_constraintHeight_percent` to 0.5.

In the `PlayerActivity.kt`, ` WindowInfoTracker` & `windowLayoutInfo` changes are used to determine the fold mode and change the layout accordingly.

### Screen Record

https://github.com/user-attachments/assets/a600d436-f2b4-4a6f-a474-29a29a3f699f

### Additional Info
[Screen Record in Samsung Z Fold](https://drive.google.com/file/d/1lOObgGr9lbUZ8TkgIgqj8lxWhW_5ovYa/view?usp=sharing) in Samsung Remote Test Lab.

If anyone is interested, check out the [Universal Signed APK](https://drive.google.com/file/d/17TpgqrJ4nxV21SKY54uZalTv8LU7SmUb/view?usp=sharing)