### PR TITLE
Introduce `Persistent Playback Speed` option

### DIFF
--- a/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/PlayerPreferences.kt
+++ b/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/PlayerPreferences.kt
@@ -12,6 +12,7 @@ data class PlayerPreferences(
     val playerScreenOrientation: ScreenOrientation = ScreenOrientation.VIDEO_ORIENTATION,
     val playerVideoZoom: VideoContentScale = VideoContentScale.BEST_FIT,
     val defaultPlaybackSpeed: Float = 1.0f,
+    val persistentPlaybackSpeed: Boolean = false,
     val autoplay: Boolean = true,
     val autoPip: Boolean = true,
     val autoBackgroundPlay: Boolean = false,

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="player_description">Player appearance, playback controls</string>
     <string name="player_name">Player</string>
     <string name="quick_settings">Quick Settings</string>
+    <string name="persistent_playback_speed">Persistent Playback Speed</string>
+    <string name="persistent_playback_speed_description">Changing playback speed changes the default with it.</string>
     <string name="autoplay_settings">Autoplay</string>
     <string name="autoplay_settings_description">Automatically play the next video in the current folder</string>
     <string name="pip_settings">Picture in Picture Mode</string>

--- a/feature/player/build.gradle.kts
+++ b/feature/player/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(project(":core:domain"))
     implementation(project(":core:model"))
     implementation(project(":core:ui"))
+    implementation(project(":feature:settings"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/MediaPlayerScreen.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/MediaPlayerScreen.kt
@@ -349,6 +349,7 @@ fun MediaPlayerScreen(
 
             OverlayShowView(
                 player = player,
+                preferencesRepository = viewModel.preferencesRepository,
                 overlayView = overlayView,
                 videoContentScale = videoZoomAndContentScaleState.videoContentScale,
                 onDismiss = { overlayView = null },

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerViewModel.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class PlayerViewModel @Inject constructor(
     private val mediaRepository: MediaRepository,
-    private val preferencesRepository: PreferencesRepository,
+    val preferencesRepository: PreferencesRepository,
     private val getSortedPlaylistUseCase: GetSortedPlaylistUseCase,
 ) : ViewModel() {
 

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/OverlayShowView.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/OverlayShowView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.media3.common.Player
+import dev.anilbeesetti.nextplayer.core.data.repository.PreferencesRepository
 import dev.anilbeesetti.nextplayer.core.model.VideoContentScale
 import dev.anilbeesetti.nextplayer.feature.player.extensions.noRippleClickable
 
@@ -13,6 +14,7 @@ import dev.anilbeesetti.nextplayer.feature.player.extensions.noRippleClickable
 fun BoxScope.OverlayShowView(
     modifier: Modifier = Modifier,
     player: Player,
+    preferencesRepository: PreferencesRepository,
     overlayView: OverlayView?,
     videoContentScale: VideoContentScale,
     onDismiss: () -> Unit = {},
@@ -47,6 +49,7 @@ fun BoxScope.OverlayShowView(
     PlaybackSpeedSelectorView(
         show = overlayView == OverlayView.PLAYBACK_SPEED,
         player = player,
+        preferencesRepository = preferencesRepository,
     )
 
     VideoContentScaleSelectorView(

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/PlaybackSpeedSelectorView.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/PlaybackSpeedSelectorView.kt
@@ -34,9 +34,12 @@ import androidx.compose.ui.unit.dp
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import dev.anilbeesetti.nextplayer.core.common.extensions.round
+import dev.anilbeesetti.nextplayer.core.data.repository.PreferencesRepository
 import dev.anilbeesetti.nextplayer.core.ui.R
 import dev.anilbeesetti.nextplayer.core.ui.components.NextSwitch
 import dev.anilbeesetti.nextplayer.feature.player.state.rememberPlaybackParametersState
+import dev.anilbeesetti.nextplayer.settings.screens.player.PlayerPreferencesUiEvent
+import dev.anilbeesetti.nextplayer.settings.screens.player.PlayerPreferencesViewModel
 
 @OptIn(UnstableApi::class)
 @Composable
@@ -44,6 +47,7 @@ fun BoxScope.PlaybackSpeedSelectorView(
     modifier: Modifier = Modifier,
     show: Boolean,
     player: Player,
+    preferencesRepository: PreferencesRepository,
 ) {
     val hapticFeedback = LocalHapticFeedback.current
     val playbackParametersState = rememberPlaybackParametersState(player)
@@ -66,6 +70,11 @@ fun BoxScope.PlaybackSpeedSelectorView(
                     val newSpeed =
                         (playbackParametersState.speed - stepSize).coerceAtLeast(minValue)
                     playbackParametersState.setPlaybackSpeed(newSpeed)
+
+                    if (preferencesRepository.playerPreferences.value.persistentPlaybackSpeed) {
+                        val viewModel = PlayerPreferencesViewModel(preferencesRepository)
+                        viewModel.onEvent(PlayerPreferencesUiEvent.UpdateDefaultPlaybackSpeed(newSpeed))
+                    }
                 },
             ) {
                 Icon(
@@ -85,6 +94,11 @@ fun BoxScope.PlaybackSpeedSelectorView(
                 onClick = {
                     val newSpeed = (playbackParametersState.speed + stepSize).coerceAtMost(maxValue)
                     playbackParametersState.setPlaybackSpeed(newSpeed)
+
+                    if (preferencesRepository.playerPreferences.value.persistentPlaybackSpeed) {
+                        val viewModel = PlayerPreferencesViewModel(preferencesRepository)
+                        viewModel.onEvent(PlayerPreferencesUiEvent.UpdateDefaultPlaybackSpeed(newSpeed))
+                    }
                 },
             ) {
                 Icon(
@@ -103,10 +117,22 @@ fun BoxScope.PlaybackSpeedSelectorView(
                 onValueChange = {
                     hapticFeedback.performHapticFeedback(HapticFeedbackType.TextHandleMove)
                     playbackParametersState.setPlaybackSpeed(it)
+
+                    if (preferencesRepository.playerPreferences.value.persistentPlaybackSpeed) {
+                        val viewModel = PlayerPreferencesViewModel(preferencesRepository)
+                        viewModel.onEvent(PlayerPreferencesUiEvent.UpdateDefaultPlaybackSpeed(it))
+                    }
                 },
                 modifier = Modifier.weight(1f),
             )
-            IconButton(onClick = { playbackParametersState.setPlaybackSpeed(1f) }) {
+            IconButton(onClick = {
+                playbackParametersState.setPlaybackSpeed(1f)
+
+                if (preferencesRepository.playerPreferences.value.persistentPlaybackSpeed) {
+                    val viewModel = PlayerPreferencesViewModel(preferencesRepository)
+                    viewModel.onEvent(PlayerPreferencesUiEvent.UpdateDefaultPlaybackSpeed(1f))
+                }
+            }) {
                 Icon(
                     painter = painterResource(R.drawable.ic_reset),
                     contentDescription = null,
@@ -129,7 +155,14 @@ fun BoxScope.PlaybackSpeedSelectorView(
                             color = LocalContentColor.current,
                             shape = CircleShape,
                         )
-                        .clickable { playbackParametersState.setPlaybackSpeed(speed) }
+                        .clickable {
+                            playbackParametersState.setPlaybackSpeed(speed)
+
+                            if (preferencesRepository.playerPreferences.value.persistentPlaybackSpeed) {
+                                val viewModel = PlayerPreferencesViewModel(preferencesRepository)
+                                viewModel.onEvent(PlayerPreferencesUiEvent.UpdateDefaultPlaybackSpeed(speed))
+                            }
+                        }
                         .padding(
                             horizontal = 8.dp,
                             vertical = 8.dp,

--- a/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/player/PlayerPreferencesScreen.kt
+++ b/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/player/PlayerPreferencesScreen.kt
@@ -268,6 +268,17 @@ private fun PlayerPreferencesContent(
                     },
                 )
                 PreferenceSwitch(
+                    title = stringResource(id = R.string.persistent_playback_speed),
+                    description = stringResource(
+                        id = R.string.persistent_playback_speed_description,
+                    ),
+                    icon = NextIcons.Speed,
+                    isChecked = uiState.preferences.persistentPlaybackSpeed,
+                    onClick = { onEvent(PlayerPreferencesUiEvent.TogglePersistentPlaybackSpeed) },
+                    index = 2,
+                    count = totalRows,
+                )
+                PreferenceSwitch(
                     title = stringResource(id = R.string.autoplay_settings),
                     description = stringResource(
                         id = R.string.autoplay_settings_description,
@@ -275,7 +286,7 @@ private fun PlayerPreferencesContent(
                     icon = NextIcons.Player,
                     isChecked = uiState.preferences.autoplay,
                     onClick = { onEvent(PlayerPreferencesUiEvent.ToggleAutoplay) },
-                    index = 2,
+                    index = 3,
                     count = totalRows,
                 )
                 PreferenceSwitch(
@@ -286,7 +297,7 @@ private fun PlayerPreferencesContent(
                     icon = NextIcons.Pip,
                     isChecked = uiState.preferences.autoPip,
                     onClick = { onEvent(PlayerPreferencesUiEvent.ToggleAutoPip) },
-                    index = 3,
+                    index = 4,
                     count = totalRows,
                 )
                 PreferenceSwitch(
@@ -297,7 +308,7 @@ private fun PlayerPreferencesContent(
                     icon = NextIcons.Headset,
                     isChecked = uiState.preferences.autoBackgroundPlay,
                     onClick = { onEvent(PlayerPreferencesUiEvent.ToggleAutoBackgroundPlay) },
-                    index = 4,
+                    index = 5,
                     count = totalRows,
                 )
                 PreferenceSwitch(
@@ -308,7 +319,7 @@ private fun PlayerPreferencesContent(
                     icon = NextIcons.Brightness,
                     isChecked = uiState.preferences.rememberPlayerBrightness,
                     onClick = { onEvent(PlayerPreferencesUiEvent.ToggleRememberBrightnessLevel) },
-                    index = 5,
+                    index = 6,
                     count = totalRows,
                 )
                 PreferenceSwitch(
@@ -317,7 +328,7 @@ private fun PlayerPreferencesContent(
                     icon = NextIcons.Selection,
                     isChecked = uiState.preferences.rememberSelections,
                     onClick = { onEvent(PlayerPreferencesUiEvent.ToggleRememberSelections) },
-                    index = 6,
+                    index = 7,
                     count = totalRows,
                 )
                 ClickablePreferenceItem(
@@ -327,7 +338,7 @@ private fun PlayerPreferencesContent(
                     onClick = {
                         onEvent(PlayerPreferencesUiEvent.ShowDialog(PlayerPreferenceDialog.PlayerScreenOrientationDialog))
                     },
-                    index = 7,
+                    index = 8,
                     count = totalRows,
                 )
             }

--- a/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/player/PlayerPreferencesViewModel.kt
+++ b/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/player/PlayerPreferencesViewModel.kt
@@ -57,6 +57,7 @@ class PlayerPreferencesViewModel @Inject constructor(
             is PlayerPreferencesUiEvent.UpdatePreferredPlayerOrientation -> updatePreferredPlayerOrientation(event.value)
             is PlayerPreferencesUiEvent.UpdatePreferredControlButtonsPosition -> updatePreferredControlButtonsPosition(event.value)
             is PlayerPreferencesUiEvent.UpdateDefaultPlaybackSpeed -> updateDefaultPlaybackSpeed(event.value)
+            PlayerPreferencesUiEvent.TogglePersistentPlaybackSpeed -> togglePersistentPlaybackSpeed()
             is PlayerPreferencesUiEvent.UpdateLongPressControlsSpeed -> updateLongPressControlsSpeed(event.value)
             is PlayerPreferencesUiEvent.UpdateControlAutoHideTimeout -> updateControlAutoHideTimeout(event.value)
             is PlayerPreferencesUiEvent.UpdateSeekIncrement -> updateSeekIncrement(event.value)
@@ -215,6 +216,14 @@ class PlayerPreferencesViewModel @Inject constructor(
         }
     }
 
+    private fun togglePersistentPlaybackSpeed() {
+        viewModelScope.launch {
+            preferencesRepository.updatePlayerPreferences {
+                it.copy(persistentPlaybackSpeed = !it.persistentPlaybackSpeed)
+            }
+        }
+    }
+
     private fun updateLongPressControlsSpeed(value: Float) {
         viewModelScope.launch {
             preferencesRepository.updatePlayerPreferences { it.copy(longPressControlsSpeed = value) }
@@ -274,6 +283,7 @@ sealed interface PlayerPreferencesUiEvent {
     data class UpdateDoubleTapGesture(val gesture: DoubleTapGesture) : PlayerPreferencesUiEvent
     data object ToggleUseLongPressControls : PlayerPreferencesUiEvent
     data object ToggleDoubleTapGesture : PlayerPreferencesUiEvent
+    data object TogglePersistentPlaybackSpeed : PlayerPreferencesUiEvent
     data object ToggleAutoplay : PlayerPreferencesUiEvent
     data object ToggleAutoPip : PlayerPreferencesUiEvent
     data object ToggleAutoBackgroundPlay : PlayerPreferencesUiEvent


### PR DESCRIPTION
Hi, this is a small modification I made for my own use.

It adds a new option that allows to automatically change the *default* playback speed every time *current* value is changed.

Since there might be others who wants something like this, I'm sharing it.