### PR TITLE
feat: add global and session video audio mute controls

### DIFF
--- a/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/PlayerPreferences.kt
+++ b/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/PlayerPreferences.kt
@@ -38,6 +38,7 @@ data class PlayerPreferences(
 
     // Audio Preferences
     val preferredAudioLanguage: String = "",
+    val muteAllVideosAudio: Boolean = false,
     val pauseOnHeadsetDisconnect: Boolean = true,
     val requireAudioFocus: Boolean = true,
     val showSystemVolumePanel: Boolean = true,

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -158,6 +158,8 @@
     <string name="pause_on_headset_disconnect_desc">Pause playback when headset disconnected from the device</string>
     <string name="system_volume_panel">System volume panel</string>
     <string name="system_volume_panel_desc">Show system volume panel while adjusting volume with headset on</string>
+    <string name="mute_all_video_audio">Mute all video audio</string>
+    <string name="mute_all_video_audio_desc">Mute audio for every video until turned off. Per-file audio track choices are preserved.</string>
     <string name="system_caption_style">System caption style</string>
     <string name="system_caption_style_desc">Click to open system captioning preferences</string>
     <string name="fields">Fields</string>
@@ -195,6 +197,7 @@
     <string name="exit">Exit</string>
     <string name="play_next_video">Play next video</string>
     <string name="skip_silence">Skip silence</string>
+    <string name="mute_for_this_session">Mute for this session</string>
     <string name="folder">Folder</string>
     <string name="folders">Folders</string>
     <string name="tree">Tree</string>

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/MediaPlayerScreen.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/MediaPlayerScreen.kt
@@ -367,6 +367,7 @@ fun MediaPlayerScreen(
                 player = player,
                 overlayView = overlayView,
                 videoContentScale = videoZoomAndContentScaleState.videoContentScale,
+                globalMuteEnabled = playerPreferences.muteAllVideosAudio,
                 onDismiss = { overlayView = null },
                 onSelectSubtitleClick = onSelectSubtitleClick,
                 onSubtitleOptionEvent = viewModel::onSubtitleOptionEvent,

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/CustomCommands.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/CustomCommands.kt
@@ -10,6 +10,8 @@ enum class CustomCommands(val customAction: String) {
     ADD_SUBTITLE_TRACK(customAction = "ADD_SUBTITLE_TRACK"),
     SET_SKIP_SILENCE_ENABLED(customAction = "SET_SKIP_SILENCE_ENABLED"),
     GET_SKIP_SILENCE_ENABLED(customAction = "GET_SKIP_SILENCE_ENABLED"),
+    SET_SESSION_MUTE_ENABLED(customAction = "SET_SESSION_MUTE_ENABLED"),
+    GET_SESSION_MUTE_ENABLED(customAction = "GET_SESSION_MUTE_ENABLED"),
     SET_IS_SCRUBBING_MODE_ENABLED(customAction = "SET_IS_SCRUBBING_MODE_ENABLED"),
     GET_AUDIO_SESSION_ID(customAction = "GET_AUDIO_SESSION_ID"),
     GET_SUBTITLE_DELAY(customAction = "GET_SUBTITLE_DELAY"),
@@ -32,6 +34,7 @@ enum class CustomCommands(val customAction: String) {
 
         const val SUBTITLE_TRACK_URI_KEY = "subtitle_track_uri"
         const val SKIP_SILENCE_ENABLED_KEY = "skip_silence_enabled"
+        const val SESSION_MUTE_ENABLED_KEY = "session_mute_enabled"
         const val IS_SCRUBBING_MODE_ENABLED_KEY = "is_scrubbing_mode_enabled"
         const val AUDIO_SESSION_ID_KEY = "audio_session_id"
         const val SUBTITLE_DELAY_KEY = "subtitle_delay"
@@ -63,6 +66,18 @@ fun MediaController.setMediaControllerIsScrubbingModeEnabled(enabled: Boolean) {
 suspend fun MediaController.getSkipSilenceEnabled(): Boolean {
     val result = sendCustomCommand(CustomCommands.GET_SKIP_SILENCE_ENABLED.sessionCommand, Bundle.EMPTY)
     return result.await().extras.getBoolean(CustomCommands.SKIP_SILENCE_ENABLED_KEY, false)
+}
+
+suspend fun MediaController.setSessionMuteEnabled(enabled: Boolean) {
+    val args = Bundle().apply {
+        putBoolean(CustomCommands.SESSION_MUTE_ENABLED_KEY, enabled)
+    }
+    sendCustomCommand(CustomCommands.SET_SESSION_MUTE_ENABLED.sessionCommand, args).await()
+}
+
+suspend fun MediaController.getSessionMuteEnabled(): Boolean {
+    val result = sendCustomCommand(CustomCommands.GET_SESSION_MUTE_ENABLED.sessionCommand, Bundle.EMPTY)
+    return result.await().extras.getBoolean(CustomCommands.SESSION_MUTE_ENABLED_KEY, false)
 }
 
 fun MediaController.setSubtitleDelayMilliseconds(delayMillis: Long) {

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/OverlayShowView.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/OverlayShowView.kt
@@ -15,6 +15,7 @@ fun BoxScope.OverlayShowView(
     player: Player,
     overlayView: OverlayView?,
     videoContentScale: VideoContentScale,
+    globalMuteEnabled: Boolean = false,
     onDismiss: () -> Unit = {},
     onSelectSubtitleClick: () -> Unit = {},
     onSubtitleOptionEvent: (SubtitleOptionsEvent) -> Unit = {},
@@ -49,6 +50,7 @@ fun BoxScope.OverlayShowView(
     PlaybackSpeedSelectorView(
         show = overlayView == OverlayView.PLAYBACK_SPEED,
         player = player,
+        globalMuteEnabled = globalMuteEnabled,
     )
 
     VideoContentScaleSelectorView(

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/PlaybackSpeedSelectorView.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/PlaybackSpeedSelectorView.kt
@@ -47,6 +47,7 @@ fun BoxScope.PlaybackSpeedSelectorView(
     modifier: Modifier = Modifier,
     show: Boolean,
     player: Player,
+    globalMuteEnabled: Boolean = false,
 ) {
     val hapticFeedback = LocalHapticFeedback.current
     val playbackParametersState = rememberPlaybackParametersState(player)
@@ -175,6 +176,32 @@ fun BoxScope.PlaybackSpeedSelectorView(
                 )
                 NextSwitch(
                     checked = playbackParametersState.skipSilenceEnabled,
+                    onCheckedChange = null,
+                )
+            }
+
+            val isMuted = globalMuteEnabled || playbackParametersState.sessionMuteEnabled
+            Row(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(4.dp))
+                    .toggleable(
+                        value = isMuted,
+                        enabled = !globalMuteEnabled,
+                        onValueChange = { playbackParametersState.setIsSessionMuteEnabled(it) },
+                    )
+                    .fillMaxWidth()
+                    .padding(8.dp)
+                    .semantics(mergeDescendants = true) {},
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.mute_for_this_session),
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.weight(1f),
+                )
+                NextSwitch(
+                    checked = isMuted,
                     onCheckedChange = null,
                 )
             }

--- a/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/audio/AudioPreferencesScreen.kt
+++ b/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/audio/AudioPreferencesScreen.kt
@@ -93,6 +93,13 @@ private fun AudioPreferencesContent(
                     isFirstItem = true,
                 )
                 PreferenceSwitch(
+                    title = stringResource(id = R.string.mute_all_video_audio),
+                    description = stringResource(id = R.string.mute_all_video_audio_desc),
+                    icon = NextIcons.VolumeUp,
+                    isChecked = uiState.preferences.muteAllVideosAudio,
+                    onClick = { onEvent(AudioPreferencesUiEvent.ToggleMuteAllVideosAudio) },
+                )
+                PreferenceSwitch(
                     title = stringResource(R.string.require_audio_focus),
                     description = stringResource(R.string.require_audio_focus_desc),
                     icon = NextIcons.Focus,

--- a/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/audio/AudioPreferencesViewModel.kt
+++ b/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/audio/AudioPreferencesViewModel.kt
@@ -41,6 +41,7 @@ class AudioPreferencesViewModel @Inject constructor(
             AudioPreferencesUiEvent.TogglePauseOnHeadsetDisconnect -> togglePauseOnHeadsetDisconnect()
             AudioPreferencesUiEvent.ToggleShowSystemVolumePanel -> toggleShowSystemVolumePanel()
             AudioPreferencesUiEvent.ToggleRequireAudioFocus -> toggleRequireAudioFocus()
+            AudioPreferencesUiEvent.ToggleMuteAllVideosAudio -> toggleMuteAllVideosAudio()
             AudioPreferencesUiEvent.ToggleVolumeBoost -> toggleVolumeBoost()
         }
     }
@@ -83,6 +84,14 @@ class AudioPreferencesViewModel @Inject constructor(
         }
     }
 
+    private fun toggleMuteAllVideosAudio() {
+        viewModelScope.launch {
+            preferencesRepository.updatePlayerPreferences {
+                it.copy(muteAllVideosAudio = !it.muteAllVideosAudio)
+            }
+        }
+    }
+
     private fun toggleVolumeBoost() {
         viewModelScope.launch {
             preferencesRepository.updatePlayerPreferences {
@@ -108,5 +117,6 @@ sealed interface AudioPreferencesUiEvent {
     data object TogglePauseOnHeadsetDisconnect : AudioPreferencesUiEvent
     data object ToggleShowSystemVolumePanel : AudioPreferencesUiEvent
     data object ToggleRequireAudioFocus : AudioPreferencesUiEvent
+    data object ToggleMuteAllVideosAudio : AudioPreferencesUiEvent
     data object ToggleVolumeBoost : AudioPreferencesUiEvent
 }


### PR DESCRIPTION
### Summary
Following this feature request: https://github.com/anilbeesetti/nextplayer/issues/1549 
This PR adds two mute capabilities for video playback while preserving existing per-file audio preferences: 

Global mute (persistent):
New audio setting: Mute all video audio.
Applies to all videos until the user turns it off.
Session mute (temporary):
New player toggle: Mute for this session (in playback speed overlay).
Applies only for the current player session.
Keeps per-file audio selection behavior intact.

### Why
Users who watch familiar videos while listening to external music can now mute all video audio quickly without manually disabling tracks for each file. As in feature request: https://github.com/anilbeesetti/nextplayer/issues/1549 

### Implementation Notes

- Added muteAllVideosAudio to PlayerPreferences.

- Added new settings UI + event handling in Audio preferences.
- Added player session commands for get/set session mute.
- Player service now applies effective mute policy: globalMute || sessionMute.
- Per-file track selections remain intact (no removal of existing per-item audio track behavior).