### PR TITLE
bug: Fix Android 14+ media access so new videos appear in library

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />

--- a/core/common/src/main/java/dev/anilbeesetti/nextplayer/core/common/Utils.kt
+++ b/core/common/src/main/java/dev/anilbeesetti/nextplayer/core/common/Utils.kt
@@ -7,10 +7,39 @@ import java.util.Locale
 import java.util.concurrent.TimeUnit
 import kotlin.math.abs
 
-val storagePermission = when {
-    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> Manifest.permission.READ_MEDIA_VIDEO
-    Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> Manifest.permission.READ_EXTERNAL_STORAGE
-    else -> Manifest.permission.WRITE_EXTERNAL_STORAGE
+fun resolveStoragePermissions(
+    sdkInt: Int = Build.VERSION.SDK_INT,
+): List<String> = when {
+    sdkInt >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> listOf(
+        Manifest.permission.READ_MEDIA_VIDEO,
+        Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+    )
+    sdkInt >= Build.VERSION_CODES.TIRAMISU -> listOf(Manifest.permission.READ_MEDIA_VIDEO)
+    sdkInt >= Build.VERSION_CODES.R -> listOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+    else -> listOf(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+}
+
+val storagePermissions = resolveStoragePermissions()
+
+val storagePermission = storagePermissions.first()
+
+fun hasFullStoragePermission(
+    permissionGrants: Map<String, Boolean>,
+    sdkInt: Int = Build.VERSION.SDK_INT,
+): Boolean = when {
+    sdkInt >= Build.VERSION_CODES.TIRAMISU -> permissionGrants[Manifest.permission.READ_MEDIA_VIDEO] == true
+    sdkInt >= Build.VERSION_CODES.R -> permissionGrants[Manifest.permission.READ_EXTERNAL_STORAGE] == true
+    else -> permissionGrants[Manifest.permission.WRITE_EXTERNAL_STORAGE] == true
+}
+
+fun hasLimitedStoragePermission(
+    permissionGrants: Map<String, Boolean>,
+    sdkInt: Int = Build.VERSION.SDK_INT,
+): Boolean {
+    if (sdkInt < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return false
+    val hasSelectedAccess = permissionGrants[Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED] == true
+    val hasFullAccess = hasFullStoragePermission(permissionGrants, sdkInt)
+    return hasSelectedAccess && !hasFullAccess
 }
 
 /**

--- a/core/common/src/main/java/dev/anilbeesetti/nextplayer/core/common/Utils.kt
+++ b/core/common/src/main/java/dev/anilbeesetti/nextplayer/core/common/Utils.kt
@@ -42,6 +42,17 @@ fun hasLimitedStoragePermission(
     return hasSelectedAccess && !hasFullAccess
 }
 
+fun shouldAutoRequestStoragePermission(
+    permissionGrants: Map<String, Boolean>,
+    alreadyRequestedInSession: Boolean,
+    sdkInt: Int = Build.VERSION.SDK_INT,
+): Boolean {
+    if (alreadyRequestedInSession) return false
+    val hasFullAccess = hasFullStoragePermission(permissionGrants, sdkInt)
+    val hasLimitedAccess = hasLimitedStoragePermission(permissionGrants, sdkInt)
+    return !hasFullAccess && !hasLimitedAccess
+}
+
 /**
  * Utility functions.
  */

--- a/core/common/src/test/java/dev/anilbeesetti/nextplayer/core/common/StoragePermissionTest.kt
+++ b/core/common/src/test/java/dev/anilbeesetti/nextplayer/core/common/StoragePermissionTest.kt
@@ -1,0 +1,63 @@
+package dev.anilbeesetti.nextplayer.core.common
+
+import android.Manifest
+import android.os.Build
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class StoragePermissionTest {
+
+    @Test
+    fun `resolveStoragePermissions returns video and selected permissions on android 14 plus`() {
+        val permissions = resolveStoragePermissions(sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+
+        assertEquals(
+            listOf(
+                Manifest.permission.READ_MEDIA_VIDEO,
+                Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+            ),
+            permissions,
+        )
+    }
+
+    @Test
+    fun `hasFullStoragePermission returns true when read media video is granted`() {
+        val hasFullAccess = hasFullStoragePermission(
+            permissionGrants = mapOf(
+                Manifest.permission.READ_MEDIA_VIDEO to true,
+                Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED to false,
+            ),
+            sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+        )
+
+        assertTrue(hasFullAccess)
+    }
+
+    @Test
+    fun `hasLimitedStoragePermission returns true when only selected media access is granted`() {
+        val hasLimitedAccess = hasLimitedStoragePermission(
+            permissionGrants = mapOf(
+                Manifest.permission.READ_MEDIA_VIDEO to false,
+                Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED to true,
+            ),
+            sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+        )
+
+        assertTrue(hasLimitedAccess)
+    }
+
+    @Test
+    fun `hasLimitedStoragePermission returns false when full access is granted`() {
+        val hasLimitedAccess = hasLimitedStoragePermission(
+            permissionGrants = mapOf(
+                Manifest.permission.READ_MEDIA_VIDEO to true,
+                Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED to true,
+            ),
+            sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+        )
+
+        assertFalse(hasLimitedAccess)
+    }
+}

--- a/core/common/src/test/java/dev/anilbeesetti/nextplayer/core/common/StoragePermissionTest.kt
+++ b/core/common/src/test/java/dev/anilbeesetti/nextplayer/core/common/StoragePermissionTest.kt
@@ -60,4 +60,46 @@ class StoragePermissionTest {
 
         assertFalse(hasLimitedAccess)
     }
+
+    @Test
+    fun `shouldAutoRequestStoragePermission returns true when no storage access has been granted yet`() {
+        val shouldAutoRequest = shouldAutoRequestStoragePermission(
+            permissionGrants = mapOf(
+                Manifest.permission.READ_MEDIA_VIDEO to false,
+                Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED to false,
+            ),
+            alreadyRequestedInSession = false,
+            sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+        )
+
+        assertTrue(shouldAutoRequest)
+    }
+
+    @Test
+    fun `shouldAutoRequestStoragePermission returns false when limited access is granted`() {
+        val shouldAutoRequest = shouldAutoRequestStoragePermission(
+            permissionGrants = mapOf(
+                Manifest.permission.READ_MEDIA_VIDEO to false,
+                Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED to true,
+            ),
+            alreadyRequestedInSession = false,
+            sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+        )
+
+        assertFalse(shouldAutoRequest)
+    }
+
+    @Test
+    fun `shouldAutoRequestStoragePermission returns false after auto request already happened in session`() {
+        val shouldAutoRequest = shouldAutoRequestStoragePermission(
+            permissionGrants = mapOf(
+                Manifest.permission.READ_MEDIA_VIDEO to false,
+                Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED to false,
+            ),
+            alreadyRequestedInSession = true,
+            sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+        )
+
+        assertFalse(shouldAutoRequest)
+    }
 }

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/sync/LocalMediaSynchronizer.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/sync/LocalMediaSynchronizer.kt
@@ -224,11 +224,14 @@ class LocalMediaSynchronizer @Inject constructor(
             val dateModifiedColumn = cursor.getColumnIndex(MediaStore.Video.Media.DATE_MODIFIED)
 
             while (cursor.moveToNext()) {
+                if (dataColumn == -1 || cursor.isNull(dataColumn)) continue
+
                 val id = cursor.getLong(idColumn)
+                val data = cursor.getString(dataColumn)
                 mediaVideos.add(
                     MediaVideo(
                         id = id,
-                        data = cursor.getString(dataColumn),
+                        data = data,
                         duration = cursor.getLong(durationColumn),
                         uri = ContentUris.withAppendedId(VIDEO_COLLECTION_URI, id),
                         width = cursor.getInt(widthColumn),
@@ -239,7 +242,7 @@ class LocalMediaSynchronizer @Inject constructor(
                 )
             }
         }
-        return mediaVideos.filter { File(it.data).exists() }
+        return mediaVideos.filter { it.data.isNotBlank() }
     }
 
     companion object {

--- a/core/ui/src/main/java/dev/anilbeesetti/nextplayer/core/ui/composables/PermissionMissingView.kt
+++ b/core/ui/src/main/java/dev/anilbeesetti/nextplayer/core/ui/composables/PermissionMissingView.kt
@@ -7,6 +7,7 @@ import dev.anilbeesetti.nextplayer.core.ui.R
 @Composable
 fun PermissionMissingView(
     isGranted: Boolean,
+    isLimitedAccess: Boolean,
     showRationale: Boolean,
     permission: String,
     launchPermissionRequest: () -> Unit,
@@ -14,6 +15,11 @@ fun PermissionMissingView(
 ) {
     if (isGranted) {
         content()
+    } else if (isLimitedAccess) {
+        PermissionRationaleDialog(
+            text = stringResource(id = R.string.permission_limited_info),
+            onConfirmButtonClick = launchPermissionRequest,
+        )
     } else if (showRationale) {
         PermissionRationaleDialog(
             text = stringResource(

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="no_videos_found">No videos found</string>
     <string name="open_settings">Open Settings</string>
     <string name="permission_info">The Next Player app needs \"%1$s\" permission to access and play media. Without it, media access and playback won\'t work. To use the app fully, grant the permission.</string>
+    <string name="permission_limited_info">Limited media access is enabled. To show newly added videos, grant full media access.</string>
     <string name="permission_not_granted">Permission Not Granted</string>
     <string name="permission_request">Permission Request</string>
     <string name="permission_settings">The Next Player app needs \"%1$s\" permission to access and play media. Without it, media access and playback won\'t work. To use the app fully, grant the permission from settings since it was permanently denied.</string>


### PR DESCRIPTION
### Issue
Newly added videos were not appearing in the media library for some users (notably Android 14+/16 devices), even after refresh/reinstall. As mentioend in: https://github.com/anilbeesetti/nextplayer/issues/1592

### Root Cause
The app treated READ_MEDIA_VIDEO as the only runtime storage permission state.
On Android 14+, users can grant limited media access (READ_MEDIA_VISUAL_USER_SELECTED), which allows only selected files.
The app did not detect this limited-access mode, so newly added videos outside the selected set were not visible.
Media sync also applied a strict file-path existence filter, which could drop valid MediaStore rows under newer scoped-storage/OEM behavior.
### Fix
Added Android 14+ permission support for limited/full media access:
Request/check both READ_MEDIA_VIDEO and READ_MEDIA_VISUAL_USER_SELECTED.
Detect and separate full access vs limited access.
Start sync only when full access is available.
Show a dedicated limited-access prompt so users can grant full access for complete library visibility.
### Updated manifest:
Added android.permission.READ_MEDIA_VISUAL_USER_SELECTED.
Hardened media sync ingestion:
Ignore rows with missing/null DATA.
Removed strict File.exists() filtering so valid indexed items are not incorrectly dropped.
### Testing Done:
Unit tests for permission resolution and full-vs-limited access detection logic.
