### PR TITLE
Add sha256 fingerprint certificate for github releases on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ the [Issues](https://github.com/anilbeesetti/nextplayer/issues) section.**
 [<img src="https://gitlab.com/IzzyOnDroid/repo/-/raw/master/assets/IzzyOnDroid.png" alt="Get it on IzzyOnDroid" height="80">](https://apt.izzysoft.de/fdroid/index/apk/dev.anilbeesetti.nextplayer)
 [<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="80">](https://f-droid.org/packages/dev.anilbeesetti.nextplayer/)
 
+> For Github releases, you can verify the app with the SHA-256 fingerprint certificate: `D3:7C:AB:F3:67:6C:F5:82:24:FB:24:2C:8D:D2:09:12:9D:05:88:03:79:29:5F:AA:A6:D0:FB:60:7B:EC:13:1B`
+
 ## Screenshots
 
 ### Media Picker


### PR DESCRIPTION
Add the SHA-256 fingerprint certificate of the apk released on github such that user can verify the app they download