### PR TITLE
long press rotate to reverse landscape  . and how to use setEffects with EditedMediaItem

### DIFF
--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/MediaPlayerScreen.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/MediaPlayerScreen.kt
@@ -319,6 +319,7 @@ fun MediaPlayerScreen(
                                     onSeek = seekGestureState::onSeek,
                                     onSeekEnd = seekGestureState::onSeekEnd,
                                     onRotateClick = rotationState::rotate,
+                                    onRotateLongClick = rotationState::rotateLong,
                                     onPlayInBackgroundClick = onPlayInBackgroundClick,
                                     onLockControlsClick = {
                                         controlsVisibilityState.showControls()

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/state/RotationState.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/state/RotationState.kt
@@ -2,6 +2,10 @@ package dev.anilbeesetti.nextplayer.feature.player.state
 
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
+import android.os.Build
+import android.view.Surface
+import android.view.WindowManager
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
@@ -14,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.core.content.ContextCompat.getSystemService
 import androidx.core.util.Consumer
 import androidx.media3.common.Player
 import androidx.media3.common.listen
@@ -47,6 +52,7 @@ class RotationState(
     private val activity: ComponentActivity,
     private val player: Player,
     private val screenOrientation: ScreenOrientation,
+    private var landscapeHint: Boolean = true
 ) {
     var currentRequestedOrientation: Int by mutableIntStateOf(activity.requestedOrientation)
         private set
@@ -55,6 +61,27 @@ class RotationState(
         activity.requestedOrientation = when (activity.resources.configuration.orientation) {
             Configuration.ORIENTATION_LANDSCAPE -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
             else -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+        }
+
+        if (landscapeHint) {
+            val text = "long press to reverse landscape "
+            Toast.makeText(activity, text, 0).show()
+            landscapeHint = false
+        }
+    }
+
+    fun rotateLong() {
+        val rotation = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activity.display?.rotation
+        } else {
+            val windowManager = getSystemService(activity, WindowManager::class.java)!!
+            windowManager.defaultDisplay.rotation
+        }
+
+        activity.requestedOrientation = when (rotation) {
+            Surface.ROTATION_90 -> ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE
+            Surface.ROTATION_270 -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+            else ->  ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
         }
     }
 

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/controls/ControlsBottomView.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/controls/ControlsBottomView.kt
@@ -80,6 +80,7 @@ fun ControlsBottomView(
     onLockControlsClick: () -> Unit,
     onPictureInPictureClick: () -> Unit,
     onRotateClick: () -> Unit,
+    onRotateLongClick: () -> Unit,
     onPlayInBackgroundClick: () -> Unit,
     onSeek: (Long) -> Unit,
     onSeekEnd: () -> Unit,
@@ -129,6 +130,7 @@ fun ControlsBottomView(
             PlayerButton(
                 modifier = modifier.size(30.dp),
                 onClick = onRotateClick,
+                onLongClick = onRotateLongClick,
             ) {
                 Icon(
                     painter = painterResource(R.drawable.ic_screen_rotation),


### PR DESCRIPTION

in bed half the time landscape is wrong depending on which side you are on

the new long press action solve this

rotate is still sensor landscape but long press override this  with the opposite direction 

unfortunately I had to flip the entire screen instead of just the picture but hopefully some one can help me with video effects for media session controller 


# simpler    solution ignore sensor  toggle from portrait to  landscape to reverse landscape 

I also made a simpler version for myself that works best for me

john-peterson/nextplayer@orient

it just ignore sensor altogether and step through two landscape modes instead  


# better solution  flip video instead

I asked about this upstream maybe they can provide a working example 

https://github.com/androidx/media/pull/3215

I tried the same thing here to apply video effects to media controller 

john-peterson/nextplayer@flip

but it failed nothing happens just like my upstream patch 

hopefully it's possible I don't see why not  . the session is only an abstract it shouldn't prevent video effects or transformer 

the effects sample has working live on the fly filter for contrast and overlays with transparency etc  . it should work in a session also there's just no working example and some bug somewhere probably on my attempt and limited understand of the library 

and the only demo I can find 

https://github.com/androidx/media/demos

composition 
effect
transformer 

that use

~~~
setEffects
setVideoEffects
~~~


apply them directly to a stand alone player that don't use a server or media controller 

~~~
MediaController
MediaSessionService
~~~

only the session demo use that and it has no effects so I'm fundamentally stumped 

is there some way to hack past custom commands and session tokens and call the player directly . if this was c I would find a pointer to the player and forget about private objects . really annoyed by the hand cuffs here because if I call that function directly on the player it probably works

I could test this and add a hard coded effect and it would work . but how can I apply it dynamically when I can't access the object 

I have to hand in the ball and take a break

i only have access to 

~~~
EditedMediaItem.setEffects
~~~

and when I use it nothing happens 

I don't know what I'm doing wrong I could spend an eternity on this I have to let go of this for now

the obvious solution is to flip the video instead of the entire screen but I can't apply any effects 

hopefully this is supposed to work and some one can fix the broken code 

I don't see anything wrong here

~~~
val mediaItem = player.currentMediaItem ?: return
val editedMediaItem = EditedMediaItem.Builder(mediaItem)
.setEffects(Effects(listOf(), effects)) // audioEffects, videoEffects
~~~

this doesn't work it just restart the video at the old position 

~~~
player.setMediaItem(editedMediaItem.mediaItem)
~~~

this doesn't work either 

~~~
player.stop()
player.setMediaItem(editedMediaItem.mediaItem)
player.prepare();
player.play();
~~~

it starts over the video from the beginning with no video filters effects

it looks correct and I can't find a single working example anywhere so I give up and hand the ball over to you 




maybe a code search on GitHub turns up something . but I only use CLI code search and it's not very good for searching in multiple lines for both keywords EditedMediaItem and setEffects

or maybe it is good but I don't know how to exclude all hits for the underlying library that is copied everywhere 

~~~
gh search code EditedMediaItem setEffects
~~~

this was the only result that was not the media library itself 

~~~
hassanabidpk/Media3Sample app/src/main/java/com/hassan/media3sample/TransformerActivity.kt
~~~

the build is broken on my remote server 
and the code is too big for my phone because he had to include ffmpeg

and he use it for a transformer instead  of a player so it's not a working example 

~~~
val transformer = Transformer.Builder(this)
    .build()
updateProgress(transformer)
transformer.start(editedMediaItemWithRotation, outputFilePath!!)
~~~


# fix filters and add rotation and brightness filters  

if you manage to fix video filters add brightness and rotation also

I also want brightness instead of system brightness i hate changing screen brightness only want to change video brightness 

this file mention rotation  gesture 

feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/PointerInputScope.kt

but it's not implemented maybe because it was impossible to apply video filters 

or some other reason 

mpv has this but it's complicated to setup and that interface is horrendous and has no pan and scan which is essential 

and free rotation only worked on desktop last time I tried the android build was stuck at 90 degrees rotation 

and there was no gesture for it only impossible hacks through custom settings 


# Todo icon size and display  . rotation icon in main tool barlandscape mode 

the rotation icon is too small

and it should be in the main tool bar in landscape mode there is plenty of space there

I seem to be the only one that use landscape when holding the phone normal vertical . I still have to reach it with my thumb I can't reach all the way to the upper edge to get back to portrait 

add R to rotate icon to indicate flipped video 

increase icon size to the same as the others so the icon is visible  

I tried this but nothing changed maybe it's locked to the text size 

~~~
Icon(
    painter = painterResource(R.drawable.ic_screen_rotation),
    // modifier = Modifier.size(12.dp),
~~~

I can't try anymore now because I have a weak signal and the apk is too big to transfer over my poor connection 


# external force rotation apps and MX pro status 

I always wanted this in MX player but could never reach him or convince him to add it

now I can't even update MX player pro anymore the apk is nowhere to be found on his website  

https://mx.j2inter.com/download

he used to have the pro APK there but now he removed it and only has the broken link

https://play.google.com/store/apps/details?id=com.mxtech.videoplayer.pro

I haven't tried the most recent MX pro but I don't think he ever added this

for me this is important 

I hate the external force landscape apps that I used for years because of this

this app stopped working for me in android 14

org.crape.rotationcontrol

this worked but I had to force close the service every time for battery drain

jp.snowlife01.android.rotationcontrol

hope I never have to use them again 


# Todo add remaining MX player functions 

the remaining MX features for me are

## sort by play date and a to z folders 

the most important feature that I still use MX for is sort folders by name and folder contents by play date

I can't find my folders if they are not alphabetical 

and I tend to play the same videos again so I sort by last played date 

I'm always going to use MX until this is added 

unless I need reverse landscape I use my build of this patch 


## single tap gesture 

single tap in the middle to play pause 

tap away from middle to show hide interface 


# more Todo features : frame step

MX never had frame step and I never found a half working player that has it

instead of resume single tap on paused frame would  step to the next frame and still be paused 

double tap would resume playback 






