### PR TITLE
Feature: Media Library: Add manual folder selection mode supporting hidden folders

### DIFF
--- a/app/src/main/java/dev/anilbeesetti/nextplayer/MainActivity.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/MainActivity.kt
@@ -108,8 +108,15 @@ class MainActivity : ComponentActivity() {
                         storagePermissionState.launchPermissionRequest()
                     }
 
-                    LaunchedEffect(key1 = storagePermissionState.status.isGranted) {
-                        if (storagePermissionState.status.isGranted) {
+                    // Manual folder selection uses SAF, so sync can start without
+                    // the media permission. startSync() is idempotent.
+                    val manualFolderSelection = (uiState as? MainActivityUiState.Success)
+                        ?.preferences?.manualFolderSelection == true
+                    LaunchedEffect(
+                        key1 = storagePermissionState.status.isGranted,
+                        key2 = manualFolderSelection,
+                    ) {
+                        if (storagePermissionState.status.isGranted || manualFolderSelection) {
                             synchronizer.startSync()
                         }
                     }

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/VideoThumbnailDecoder.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/VideoThumbnailDecoder.kt
@@ -95,10 +95,19 @@ class VideoThumbnailDecoder(
         val rawBitmap = MediaMetadataRetriever().use { nativeRetriever ->
             MediaThumbnailRetriever().use { ffmpegRetriever ->
                 nativeRetriever.setDataSource(source)
-                ffmpegRetriever.setDataSource(source)
+                // The ffmpeg retriever can't open SAF content:// URIs
+                // (manual/hidden folders); degrade to native-only instead
+                // of failing the whole thumbnail.
+                val ffmpegOk = try {
+                    ffmpegRetriever.setDataSource(source)
+                    true
+                } catch (e: Exception) {
+                    false
+                }
 
                 // First, try to get embedded picture (album art/metadata thumbnail)
-                val embeddedPicture = nativeRetriever.embeddedPicture ?: ffmpegRetriever.getEmbeddedPicture()
+                val embeddedPicture = nativeRetriever.embeddedPicture
+                    ?: if (ffmpegOk) ffmpegRetriever.getEmbeddedPicture() else null
                 val embeddedPictureBitmap = embeddedPicture?.let { pictureBytes ->
                     BitmapFactory.decodeByteArray(pictureBytes, 0, pictureBytes.size)
                 }
@@ -109,21 +118,24 @@ class VideoThumbnailDecoder(
                     .extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
                     ?.toLongOrNull() ?: 0L
 
+                fun ffmpegFrame(timeUs: Long) =
+                    if (ffmpegOk) ffmpegRetriever.getFrameAtTime(timeUs) else null
+
                 return@use when (strategy) {
                     is ThumbnailStrategy.FirstFrame -> {
-                        nativeRetriever.getFrameAtTime(0) ?: ffmpegRetriever.getFrameAtTime(0)
+                        nativeRetriever.getFrameAtTime(0) ?: ffmpegFrame(0)
                     }
 
                     is ThumbnailStrategy.FrameAtPercentage -> {
                         val timeUs = (videoDuration * strategy.percentage * 1000).toLong()
-                        nativeRetriever.getFrameAtTime(timeUs) ?: ffmpegRetriever.getFrameAtTime(timeUs)
+                        nativeRetriever.getFrameAtTime(timeUs) ?: ffmpegFrame(timeUs)
                     }
 
                     is ThumbnailStrategy.Hybrid -> {
                         val firstFrame = nativeRetriever.getFrameAtTime(0)
                         if (firstFrame == null || isSolidColor(firstFrame)) {
                             val timeUs = (videoDuration * strategy.percentage * 1000).toLong()
-                            nativeRetriever.getFrameAtTime(timeUs) ?: ffmpegRetriever.getFrameAtTime(timeUs)
+                            nativeRetriever.getFrameAtTime(timeUs) ?: ffmpegFrame(timeUs)
                         } else {
                             firstFrame
                         }
@@ -271,7 +283,7 @@ class VideoThumbnailDecoder(
             options: Options,
             imageLoader: ImageLoader,
         ): Decoder? {
-            if (!isApplicable(result.mimeType)) return null
+            if (!isApplicable(result)) return null
             return VideoThumbnailDecoder(
                 source = result.source,
                 options = options,
@@ -280,8 +292,28 @@ class VideoThumbnailDecoder(
             )
         }
 
-        private fun isApplicable(mimeType: String?): Boolean {
-            return mimeType != null && mimeType.startsWith("video/")
+        private fun isApplicable(result: SourceFetchResult): Boolean {
+            val mimeType = result.mimeType
+            if (mimeType != null && mimeType.startsWith("video/")) return true
+            // Don't hijack real image/audio content.
+            if (mimeType != null &&
+                (mimeType.startsWith("image/") || mimeType.startsWith("audio/"))
+            ) {
+                return false
+            }
+            // SAF tree-document URIs (manually picked / hidden folders) often
+            // report no mime type or a generic one (application/octet-stream),
+            // so fall back to the URI's video extension.
+            val uri = (result.source.metadata as? ContentMetadata)?.uri ?: return false
+            val extension = uri.toString().substringAfterLast('.', "").lowercase()
+            return extension in VIDEO_EXTENSIONS
+        }
+
+        private companion object {
+            val VIDEO_EXTENSIONS = setOf(
+                "mp4", "mkv", "webm", "avi", "mov", "flv", "wmv", "m4v",
+                "3gp", "ts", "m2ts", "mts", "mpg", "mpeg", "ogv", "vob",
+            )
         }
     }
 }

--- a/core/domain/src/main/java/dev/anilbeesetti/nextplayer/core/domain/GetSortedFolderTreeUseCase.kt
+++ b/core/domain/src/main/java/dev/anilbeesetti/nextplayer/core/domain/GetSortedFolderTreeUseCase.kt
@@ -52,7 +52,11 @@ class GetSortedFolderTreeUseCase @Inject constructor(
         preferences: ApplicationPreferences,
     ): List<Folder> {
         return filter {
-            it.parentPath == path && it.path !in preferences.excludeFolders
+            // it.path != path guards against a self-referential directory
+            // (parentPath == path) causing infinite recursion. The exclude
+            // list applies to MediaStore mode only.
+            it.parentPath == path && it.path != path &&
+                (preferences.manualFolderSelection || it.path !in preferences.excludeFolders)
         }.map { directory ->
             Folder(
                 name = directory.name,

--- a/core/domain/src/main/java/dev/anilbeesetti/nextplayer/core/domain/GetSortedFoldersUseCase.kt
+++ b/core/domain/src/main/java/dev/anilbeesetti/nextplayer/core/domain/GetSortedFoldersUseCase.kt
@@ -24,8 +24,11 @@ class GetSortedFoldersUseCase @Inject constructor(
             preferencesRepository.applicationPreferences,
         ) { folders, preferences ->
 
+            // Exclude list applies to MediaStore mode only; manual selection
+            // has its own explicit folder list.
             val nonExcludedDirectories = folders.filter {
-                it.mediaList.isNotEmpty() && it.path !in preferences.excludeFolders
+                it.mediaList.isNotEmpty() &&
+                    (preferences.manualFolderSelection || it.path !in preferences.excludeFolders)
             }
 
             val sort = Sort(by = preferences.sortBy, order = preferences.sortOrder)

--- a/core/domain/src/main/java/dev/anilbeesetti/nextplayer/core/domain/GetSortedVideosUseCase.kt
+++ b/core/domain/src/main/java/dev/anilbeesetti/nextplayer/core/domain/GetSortedVideosUseCase.kt
@@ -31,8 +31,10 @@ class GetSortedVideosUseCase @Inject constructor(
             preferencesRepository.applicationPreferences,
         ) { videoItems, preferences ->
 
+            // The exclude list belongs to MediaStore mode; manual selection
+            // has its own explicit folder list, so it is not applied there.
             val nonExcludedVideos = videoItems.filterNot {
-                it.parentPath in preferences.excludeFolders
+                !preferences.manualFolderSelection && it.parentPath in preferences.excludeFolders
             }
 
             val sort = Sort(by = preferences.sortBy, order = preferences.sortOrder)

--- a/core/media/build.gradle.kts
+++ b/core/media/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
 dependencies {
     implementation(project(":core:common"))
     implementation(project(":core:database"))
+    implementation(project(":core:datastore"))
     implementation(project(":core:model"))
 
     implementation(libs.androidx.core.ktx)

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/sync/DocumentTreeScanner.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/sync/DocumentTreeScanner.kt
@@ -1,0 +1,148 @@
+package dev.anilbeesetti.nextplayer.core.media.sync
+
+import android.content.Context
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import android.provider.DocumentsContract
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.anilbeesetti.nextplayer.core.common.extensions.getPath
+import dev.anilbeesetti.nextplayer.core.media.model.MediaVideo
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Walks user-picked SAF tree URIs (which, unlike MediaStore, expose hidden
+ * "dot" folders) and returns the video files found inside them.
+ */
+class DocumentTreeScanner @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+
+    suspend fun scan(treeUris: List<String>): List<MediaVideo> = withContext(Dispatchers.IO) {
+        treeUris.flatMap { uriString ->
+            runCatching { scanTree(Uri.parse(uriString)) }.getOrDefault(emptyList())
+        }
+    }
+
+    private fun scanTree(treeUri: Uri): List<MediaVideo> {
+        val result = mutableListOf<MediaVideo>()
+        val rootDocId = DocumentsContract.getTreeDocumentId(treeUri)
+        val pending = ArrayDeque<String>()
+        pending.add(rootDocId)
+
+        while (pending.isNotEmpty()) {
+            val parentDocId = pending.removeFirst()
+            val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(treeUri, parentDocId)
+
+            val entries = mutableListOf<DocEntry>()
+            context.contentResolver.query(
+                childrenUri,
+                arrayOf(
+                    DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                    DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                    DocumentsContract.Document.COLUMN_MIME_TYPE,
+                    DocumentsContract.Document.COLUMN_SIZE,
+                    DocumentsContract.Document.COLUMN_LAST_MODIFIED,
+                ),
+                null,
+                null,
+                null,
+            )?.use { cursor ->
+                while (cursor.moveToNext()) {
+                    val name = cursor.getString(1) ?: continue
+                    entries.add(
+                        DocEntry(
+                            docId = cursor.getString(0),
+                            name = name,
+                            mime = cursor.getString(2),
+                            size = cursor.getLong(3),
+                            lastModified = cursor.getLong(4),
+                        ),
+                    )
+                }
+            }
+
+            // Honor .nomedia for descendant folders, but always scan the
+            // folder the user explicitly picked (the tree root).
+            val isRoot = parentDocId == rootDocId
+            if (!isRoot && entries.any { it.name == NOMEDIA }) continue
+
+            for (entry in entries) {
+                if (entry.mime == DocumentsContract.Document.MIME_TYPE_DIR) {
+                    pending.add(entry.docId)
+                } else if (isVideo(entry.mime, entry.name)) {
+                    val docUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, entry.docId)
+                    result.add(
+                        buildMediaVideo(docUri, entry.docId, entry.name, entry.size, entry.lastModified),
+                    )
+                }
+            }
+        }
+        return result
+    }
+
+    private data class DocEntry(
+        val docId: String,
+        val name: String,
+        val mime: String?,
+        val size: Long,
+        val lastModified: Long,
+    )
+
+    private fun buildMediaVideo(
+        docUri: Uri,
+        docId: String,
+        name: String,
+        size: Long,
+        lastModified: Long,
+    ): MediaVideo {
+        // A stable, path-shaped string so the existing path-based DB grouping works.
+        val path = context.getPath(docUri)
+            ?: "/" + docId.substringAfter(':', name).trimStart('/')
+
+        var duration = 0L
+        var width = 0
+        var height = 0
+        val retriever = MediaMetadataRetriever()
+        try {
+            retriever.setDataSource(context, docUri)
+            duration = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                ?.toLongOrNull() ?: 0L
+            width = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
+                ?.toIntOrNull() ?: 0
+            height = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
+                ?.toIntOrNull() ?: 0
+        } catch (e: Exception) {
+            e.printStackTrace()
+        } finally {
+            runCatching { retriever.release() }
+        }
+
+        return MediaVideo(
+            id = 0L,
+            uri = docUri,
+            size = size,
+            width = width,
+            height = height,
+            data = path,
+            duration = duration,
+            dateModified = lastModified,
+        )
+    }
+
+    private fun isVideo(mime: String?, name: String): Boolean {
+        if (mime != null && mime.startsWith("video/")) return true
+        val ext = name.substringAfterLast('.', "").lowercase()
+        return ext in VIDEO_EXTENSIONS
+    }
+
+    companion object {
+        private const val NOMEDIA = ".nomedia"
+
+        private val VIDEO_EXTENSIONS = setOf(
+            "mp4", "mkv", "webm", "avi", "mov", "flv", "wmv", "m4v",
+            "3gp", "ts", "m2ts", "mts", "mpg", "mpeg", "ogv", "vob",
+        )
+    }
+}

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/sync/LocalMediaSynchronizer.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/sync/LocalMediaSynchronizer.kt
@@ -21,21 +21,26 @@ import dev.anilbeesetti.nextplayer.core.database.dao.MediumDao
 import dev.anilbeesetti.nextplayer.core.database.dao.MediumStateDao
 import dev.anilbeesetti.nextplayer.core.database.entities.DirectoryEntity
 import dev.anilbeesetti.nextplayer.core.database.entities.MediumEntity
+import dev.anilbeesetti.nextplayer.core.datastore.datasource.AppPreferencesDataSource
 import dev.anilbeesetti.nextplayer.core.media.model.MediaVideo
 import java.io.File
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -44,6 +49,8 @@ class LocalMediaSynchronizer @Inject constructor(
     private val mediumStateDao: MediumStateDao,
     private val directoryDao: DirectoryDao,
     private val imageLoader: ImageLoader,
+    private val appPreferencesDataSource: AppPreferencesDataSource,
+    private val documentTreeScanner: DocumentTreeScanner,
     @ApplicationScope private val applicationScope: CoroutineScope,
     @ApplicationContext private val context: Context,
     @Dispatcher(NextDispatchers.IO) private val dispatcher: CoroutineDispatcher,
@@ -51,18 +58,94 @@ class LocalMediaSynchronizer @Inject constructor(
 
     private var mediaSyncingJob: Job? = null
 
+    // Forces a re-scan in manual mode even when the picked folders are unchanged.
+    private val manualRefreshTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
     override suspend fun refresh(path: String?): Boolean {
+        val preferences = appPreferencesDataSource.preferences.first()
+        if (preferences.manualFolderSelection) {
+            manualRefreshTrigger.emit(Unit)
+            // Minimal delay so the pull-to-refresh spinner is actually visible.
+            delay(MANUAL_REFRESH_FEEDBACK_MS)
+            return true
+        }
         return path?.let { context.scanPaths(listOf(path)) }
             ?: context.getStorageVolumes().all { context.scanStorage(it.path) }
     }
 
+    @Synchronized
     override fun startSync() {
         if (mediaSyncingJob != null) return
-        mediaSyncingJob = getMediaVideosFlow().onEach { media ->
-            applicationScope.launch { updateDirectories(media) }
-            applicationScope.launch { updateMedia(media) }
-        }.launchIn(applicationScope)
+        mediaSyncingJob = applicationScope.launch {
+            // collectLatest only cancels the inner block when the mode/folders
+            // actually change (rare, user-initiated) - never mid-scan from a
+            // hot preference emission, so blocking scans aren't yanked.
+            appPreferencesDataSource.preferences
+                .map { ManualMode(it.manualFolderSelection, it.manuallySelectedFolders) }
+                .distinctUntilChanged()
+                .collectLatest { mode ->
+                    if (mode.manual) {
+                        manualRefreshTrigger.onStart { emit(Unit) }.collect {
+                            val media = try {
+                                documentTreeScanner.scan(mode.folders)
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Exception) {
+                                e.printStackTrace()
+                                return@collect
+                            }
+                            safely { updateDirectoriesFromMedia(media) }
+                            safely { updateMedia(media) }
+                        }
+                    } else {
+                        getMediaVideosFlow().collect { media ->
+                            safely { updateDirectories(media) }
+                            safely { updateMedia(media) }
+                        }
+                    }
+                }
+        }
     }
+
+    private data class ManualMode(val manual: Boolean, val folders: List<String>)
+
+    // Logs failures but never swallows cancellation (keeps structured concurrency intact).
+    private suspend fun safely(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    // Manual mode can't traverse the filesystem (scoped storage), so directories
+    // are derived from the scanned media paths. Only the media's parent folders
+    // are created - never the filesystem root and never a self-referential node
+    // (parentPath == path), which would make the folder-tree recursion loop.
+    private suspend fun updateDirectoriesFromMedia(media: List<MediaVideo>) =
+        withContext(Dispatchers.Default) {
+            val directories = media
+                .mapNotNull { File(it.data).parentFile }
+                .distinctBy { it.path }
+                .filter { it.path.isNotEmpty() && it.path != "/" }
+                .map { dir ->
+                    DirectoryEntity(
+                        path = dir.path,
+                        name = dir.name.ifEmpty { dir.path },
+                        modified = dir.lastModified(),
+                        parentPath = dir.parentFile?.path
+                            ?.takeIf { it.isNotEmpty() && it != dir.path } ?: "/",
+                    )
+                }
+            directoryDao.upsertAll(directories)
+
+            val currentDirectoryPaths = directories.map { it.path }
+            val unwantedDirectories = directoryDao.getAll().first()
+                .filterNot { it.path in currentDirectoryPaths }
+            directoryDao.delete(unwantedDirectories.map { it.path })
+        }
 
     override fun stopSync() {
         mediaSyncingJob?.cancel()
@@ -243,6 +326,8 @@ class LocalMediaSynchronizer @Inject constructor(
     }
 
     companion object {
+        private const val MANUAL_REFRESH_FEEDBACK_MS = 350L
+
         val VIDEO_PROJECTION = arrayOf(
             MediaStore.Video.Media._ID,
             MediaStore.Video.Media.DATA,

--- a/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/ApplicationPreferences.kt
+++ b/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/ApplicationPreferences.kt
@@ -10,6 +10,10 @@ data class ApplicationPreferences(
     val useHighContrastDarkTheme: Boolean = false,
     val useDynamicColors: Boolean = true,
     val markLastPlayedMedia: Boolean = true,
+    // When enabled, the library is built only from manually picked folders
+    // (SAF tree URIs), which can include hidden (dot) folders.
+    val manualFolderSelection: Boolean = false,
+    val manuallySelectedFolders: List<String> = emptyList(),
     val excludeFolders: List<String> = emptyList(),
     val mediaViewMode: MediaViewMode = MediaViewMode.FOLDERS,
     val mediaLayoutMode: MediaLayoutMode = MediaLayoutMode.LIST,

--- a/core/ui/src/main/java/dev/anilbeesetti/nextplayer/core/ui/designsystem/NextIcons.kt
+++ b/core/ui/src/main/java/dev/anilbeesetti/nextplayer/core/ui/designsystem/NextIcons.kt
@@ -4,6 +4,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.automirrored.rounded.CompareArrows
 import androidx.compose.material.icons.automirrored.rounded.VolumeUp
+import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.AppSettingsAlt
 import androidx.compose.material.icons.rounded.ArrowDownward
 import androidx.compose.material.icons.rounded.ArrowUpward
@@ -77,6 +78,7 @@ import androidx.compose.material.icons.rounded.Tune
 import androidx.compose.material.icons.rounded.Update
 
 object NextIcons {
+    val Add = Icons.Rounded.Add
     val Appearance = Icons.Rounded.Palette
     val ArrowBack = Icons.AutoMirrored.Rounded.ArrowBack
     val ArrowDownward = Icons.Rounded.ArrowDownward

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -192,6 +192,12 @@
     <string name="rename_to">Rename to</string>
     <string name="mark_last_played_media">Mark last played media</string>
     <string name="mark_last_played_media_desc">Mark last played media in home and in each folder</string>
+    <string name="select_folders_manually">Select folders manually</string>
+    <string name="select_folders_manually_desc">Pick any folder as part of your library. Supports hidden folders.</string>
+    <string name="add_folder">Add folder</string>
+    <string name="no_manual_folders">No folders added yet. Tap “Add folder” to pick one.</string>
+    <string name="library_folders">Library folders</string>
+    <string name="library_folders_desc">Add or remove</string>
     <string name="open_local_video">Open local video</string>
     <string name="open_network_stream">Open network stream</string>
     <string name="exit">Exit</string>

--- a/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/medialibrary/FolderPreferencesScreen.kt
+++ b/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/medialibrary/FolderPreferencesScreen.kt
@@ -1,5 +1,7 @@
 package dev.anilbeesetti.nextplayer.settings.screens.medialibrary
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -12,9 +14,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -28,6 +32,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dev.anilbeesetti.nextplayer.core.ui.R
 import dev.anilbeesetti.nextplayer.core.ui.base.DataState
 import dev.anilbeesetti.nextplayer.core.ui.components.NextTopAppBar
+import dev.anilbeesetti.nextplayer.core.ui.components.PreferenceItem
 import dev.anilbeesetti.nextplayer.core.ui.components.SelectablePreference
 import dev.anilbeesetti.nextplayer.core.ui.designsystem.NextIcons
 import dev.anilbeesetti.nextplayer.core.ui.extensions.plus
@@ -40,10 +45,17 @@ fun FolderPreferencesScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle(minActiveState = Lifecycle.State.RESUMED)
 
+    val folderPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocumentTree(),
+    ) { uri ->
+        if (uri != null) viewModel.onEvent(FolderPreferencesUiEvent.AddFolder(uri))
+    }
+
     FolderPreferencesContent(
         uiState = uiState,
         onNavigateUp = onNavigateUp,
         onEvent = viewModel::onEvent,
+        onAddFolderClick = { folderPicker.launch(null) },
     )
 }
 
@@ -53,6 +65,7 @@ private fun FolderPreferencesContent(
     uiState: FolderPreferencesUiState,
     onNavigateUp: () -> Unit,
     onEvent: (FolderPreferencesUiEvent) -> Unit,
+    onAddFolderClick: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -70,6 +83,16 @@ private fun FolderPreferencesContent(
         },
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
     ) { innerPadding ->
+        if (uiState.preferences.manualFolderSelection) {
+            ManualFoldersList(
+                manualFolders = uiState.manualFolders,
+                contentPadding = innerPadding + PaddingValues(horizontal = 16.dp),
+                onAddFolderClick = onAddFolderClick,
+                onRemove = { onEvent(FolderPreferencesUiEvent.RemoveFolder(it)) },
+            )
+            return@Scaffold
+        }
+
         when (uiState.foldersDataState) {
             is DataState.Loading -> {
                 Box(
@@ -105,6 +128,61 @@ private fun FolderPreferencesContent(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun ManualFoldersList(
+    manualFolders: List<ManualFolder>,
+    contentPadding: PaddingValues,
+    onAddFolderClick: () -> Unit,
+    onRemove: (String) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = contentPadding,
+        verticalArrangement = Arrangement.spacedBy(ListItemDefaults.SegmentedGap),
+    ) {
+        item {
+            PreferenceItem(
+                title = stringResource(id = R.string.add_folder),
+                icon = NextIcons.Add,
+                enabled = true,
+                onClick = onAddFolderClick,
+                isFirstItem = true,
+                isLastItem = true,
+            )
+        }
+        if (manualFolders.isEmpty()) {
+            item {
+                Text(
+                    text = stringResource(id = R.string.no_manual_folders),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(16.dp),
+                )
+            }
+        } else {
+            itemsIndexed(manualFolders) { index, folder ->
+                PreferenceItem(
+                    title = folder.displayPath.substringAfterLast('/').ifEmpty { folder.displayPath },
+                    description = folder.displayPath,
+                    icon = NextIcons.Folder,
+                    enabled = true,
+                    isFirstItem = index == 0,
+                    isLastItem = index == manualFolders.lastIndex,
+                    trailingContent = {
+                        IconButton(onClick = { onRemove(folder.uriString) }) {
+                            Icon(
+                                imageVector = NextIcons.Delete,
+                                contentDescription = stringResource(id = R.string.remove),
+                            )
+                        }
+                    },
+                )
+            }
+        }
+    }
+}
+
 @PreviewLightDark
 @Composable
 private fun FolderPreferencesScreenPreview() {
@@ -113,6 +191,7 @@ private fun FolderPreferencesScreenPreview() {
             uiState = FolderPreferencesUiState(),
             onNavigateUp = {},
             onEvent = {},
+            onAddFolderClick = {},
         )
     }
 }

--- a/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/medialibrary/FolderPreferencesViewModel.kt
+++ b/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/medialibrary/FolderPreferencesViewModel.kt
@@ -1,8 +1,13 @@
 package dev.anilbeesetti.nextplayer.settings.screens.medialibrary
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.DocumentsContract
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.anilbeesetti.nextplayer.core.data.repository.MediaRepository
 import dev.anilbeesetti.nextplayer.core.data.repository.PreferencesRepository
 import dev.anilbeesetti.nextplayer.core.model.ApplicationPreferences
@@ -12,11 +17,13 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 @HiltViewModel
 class FolderPreferencesViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     mediaRepository: MediaRepository,
     private val preferencesRepository: PreferencesRepository,
 ) : ViewModel() {
@@ -30,25 +37,28 @@ class FolderPreferencesViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            mediaRepository.getFoldersFlow().collect {
+            combine(
+                mediaRepository.getFoldersFlow(),
+                preferencesRepository.applicationPreferences,
+            ) { folders, preferences ->
                 uiStateInternal.update { currentState ->
-                    currentState.copy(foldersDataState = DataState.Success(it))
+                    currentState.copy(
+                        foldersDataState = DataState.Success(folders),
+                        preferences = preferences,
+                        manualFolders = preferences.manuallySelectedFolders.map { uri ->
+                            ManualFolder(uriString = uri, displayPath = uri.toTreeDisplayPath())
+                        },
+                    )
                 }
-            }
-        }
-
-        viewModelScope.launch {
-            preferencesRepository.applicationPreferences.collect { preferences ->
-                uiStateInternal.update { currentState ->
-                    currentState.copy(preferences = preferences)
-                }
-            }
+            }.collect {}
         }
     }
 
     fun onEvent(event: FolderPreferencesUiEvent) {
         when (event) {
             is FolderPreferencesUiEvent.UpdateExcludeList -> updateExcludeList(event.path)
+            is FolderPreferencesUiEvent.AddFolder -> addFolder(event.uri)
+            is FolderPreferencesUiEvent.RemoveFolder -> removeFolder(event.uriString)
         }
     }
 
@@ -65,13 +75,60 @@ class FolderPreferencesViewModel @Inject constructor(
             }
         }
     }
+
+    private fun addFolder(uri: Uri) {
+        viewModelScope.launch {
+            runCatching {
+                context.contentResolver.takePersistableUriPermission(
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            }
+            preferencesRepository.updateApplicationPreferences {
+                if (uri.toString() in it.manuallySelectedFolders) {
+                    it
+                } else {
+                    it.copy(manuallySelectedFolders = it.manuallySelectedFolders + uri.toString())
+                }
+            }
+        }
+    }
+
+    private fun removeFolder(uriString: String) {
+        viewModelScope.launch {
+            runCatching {
+                context.contentResolver.releasePersistableUriPermission(
+                    Uri.parse(uriString),
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            }
+            preferencesRepository.updateApplicationPreferences {
+                it.copy(manuallySelectedFolders = it.manuallySelectedFolders - uriString)
+            }
+        }
+    }
 }
+
+// Turns a SAF tree URI into a readable "/Movies/.hidden" style path.
+private fun String.toTreeDisplayPath(): String = runCatching {
+    val docId = DocumentsContract.getTreeDocumentId(Uri.parse(this))
+    val relative = docId.substringAfter(':', "")
+    if (relative.isEmpty()) docId else "/$relative"
+}.getOrDefault(this)
+
+data class ManualFolder(
+    val uriString: String,
+    val displayPath: String,
+)
 
 data class FolderPreferencesUiState(
     val foldersDataState: DataState<List<Folder>> = DataState.Loading,
     val preferences: ApplicationPreferences = ApplicationPreferences(),
+    val manualFolders: List<ManualFolder> = emptyList(),
 )
 
 sealed interface FolderPreferencesUiEvent {
     data class UpdateExcludeList(val path: String) : FolderPreferencesUiEvent
+    data class AddFolder(val uri: Uri) : FolderPreferencesUiEvent
+    data class RemoveFolder(val uriString: String) : FolderPreferencesUiEvent
 }

--- a/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/medialibrary/MediaLibraryPreferencesScreen.kt
+++ b/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/medialibrary/MediaLibraryPreferencesScreen.kt
@@ -103,12 +103,37 @@ private fun MediaLibraryPreferencesContent(
             Column(
                 verticalArrangement = Arrangement.spacedBy(ListItemDefaults.SegmentedGap),
             ) {
-                ClickablePreferenceItem(
-                    title = stringResource(id = R.string.manage_folders),
-                    description = stringResource(id = R.string.manage_folders_desc),
-                    icon = NextIcons.FolderOff,
-                    onClick = onFolderSettingClick,
+                PreferenceSwitch(
+                    title = stringResource(id = R.string.select_folders_manually),
+                    description = stringResource(id = R.string.select_folders_manually_desc),
+                    icon = NextIcons.CheckBox,
+                    isChecked = preferences.manualFolderSelection,
+                    onClick = { onEvent(MediaLibraryPreferencesUiEvent.ToggleManualFolderSelection) },
                     isFirstItem = true,
+                    isLastItem = false,
+                )
+                ClickablePreferenceItem(
+                    title = stringResource(
+                        id = if (preferences.manualFolderSelection) {
+                            R.string.library_folders
+                        } else {
+                            R.string.manage_folders
+                        },
+                    ),
+                    description = stringResource(
+                        id = if (preferences.manualFolderSelection) {
+                            R.string.library_folders_desc
+                        } else {
+                            R.string.manage_folders_desc
+                        },
+                    ),
+                    icon = if (preferences.manualFolderSelection) {
+                        NextIcons.Folder
+                    } else {
+                        NextIcons.FolderOff
+                    },
+                    onClick = onFolderSettingClick,
+                    isFirstItem = false,
                     isLastItem = true,
                 )
             }

--- a/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/medialibrary/MediaLibraryPreferencesViewModel.kt
+++ b/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/medialibrary/MediaLibraryPreferencesViewModel.kt
@@ -33,6 +33,7 @@ class MediaLibraryPreferencesViewModel @Inject constructor(
     fun onEvent(event: MediaLibraryPreferencesUiEvent) {
         when (event) {
             MediaLibraryPreferencesUiEvent.ToggleMarkLastPlayedMedia -> toggleMarkLastPlayedMedia()
+            MediaLibraryPreferencesUiEvent.ToggleManualFolderSelection -> toggleManualFolderSelection()
         }
     }
 
@@ -40,6 +41,14 @@ class MediaLibraryPreferencesViewModel @Inject constructor(
         viewModelScope.launch {
             preferencesRepository.updateApplicationPreferences {
                 it.copy(markLastPlayedMedia = !it.markLastPlayedMedia)
+            }
+        }
+    }
+
+    private fun toggleManualFolderSelection() {
+        viewModelScope.launch {
+            preferencesRepository.updateApplicationPreferences {
+                it.copy(manualFolderSelection = !it.manualFolderSelection)
             }
         }
     }
@@ -51,4 +60,5 @@ data class MediaLibraryPreferencesUiState(
 
 sealed interface MediaLibraryPreferencesUiEvent {
     data object ToggleMarkLastPlayedMedia : MediaLibraryPreferencesUiEvent
+    data object ToggleManualFolderSelection : MediaLibraryPreferencesUiEvent
 }


### PR DESCRIPTION
Adds a 'Select folders manually' toggle in Media library settings. When enabled, the library is built only from folders the user picks with the system folder picker (OpenDocumentTree).

In this mode the app does its own folder scanning and does **not** rely on MediaStore.

_Warning: coded with AI, take it or leave it, won't take any offense if you don't._

-  Each picked folder tree is crawledrecursively via DocumentsContract, so folders MediaStore never indexes (hidden/dot folders, folders with `.nomedia`, app folders like Telegram, etc.) are included. Normal (non-manual) MediaStore mode is untouched.
- No broad storage permission: access is granted per-folder by the system folder picker (SAF) and kept via a persistable read URI permission. No `MANAGE_EXTERNAL_STORAGE` / All-files access, and no new manifest permissions.
- Nested subfolders are scanned at any depth. The explicitly picked folder is always scanned; descendant folders containing a `.nomedia` are skipped.
- Manage folders becomes an add/remove list in manual mode.
- The MediaStore-only exclude-folders list is not applied in manual mode (manual selection is its own explicit list).
- Thumbnails: the ffmpeg retriever can't open SAF content URIs, so it is now optional and the native retriever produces the frame; the video decoder also applies when the mime type is unknown/generic but the URI has a video extension.
- Folder-tree recursion guarded against self-referential nodes.
- Minimal delay on manual refresh so the pull-to-refresh spinner shows.

Closes #1038, Closes #1126, Closes #467, Closes #1719

Related to #965, #1086, #1132, #1193, #1209, #1210, #1373, #1694

<img width="300" alt="image" src="https://github.com/user-attachments/assets/3db28aa4-e598-4563-9b1c-59d8e309a189" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/680f4fde-1ed5-444c-b48b-9bb5af517298" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/9f9c2915-b9ee-4974-b002-1222eab94d96" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1744bc75-b4c1-49cb-80fc-5cc36ed8b351" />
