### PR TITLE
Fix subtitle loading bugs: preserve orientation and playback speed

### DIFF
--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/Player.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/Player.kt
@@ -73,15 +73,16 @@ fun Player.addAdditionalSubtitleConfiguration(subtitle: MediaItem.SubtitleConfig
         return
     }
 
+    val savedSpeed = playbackParameters.speed
+
     val updateMediaItem = currentMediaItemLocal
         .buildUpon()
         .setSubtitleConfigurations(existingSubConfigurations + listOf(subtitle))
         .build()
 
     val index = currentMediaItemIndex
-    addMediaItem(index + 1, updateMediaItem)
-    seekTo(index + 1, currentPosition)
-    removeMediaItem(index)
+    replaceMediaItem(index, updateMediaItem)
+    setPlaybackSpeed(savedSpeed)
 }
 
 @OptIn(UnstableApi::class)

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/state/RotationState.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/state/RotationState.kt
@@ -95,7 +95,7 @@ class RotationState(
     }
 
     private fun getVideoBasedOrientation() = when {
-        player.videoSize.width == 0 || player.videoSize.height == 0 -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+        player.videoSize.width == 0 || player.videoSize.height == 0 -> activity.requestedOrientation
         player.videoSize.isPortrait -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
         else -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
     }


### PR DESCRIPTION
## Description

Two bugs fixed when loading external subtitles via the "Open subtitle" button:

### Bug 1: Landscape → Portrait orientation flip
**Root cause:** `addAdditionalSubtitleConfiguration()` in `Player.kt` used `addMediaItem` + `seekTo` + `removeMediaItem` to replace the current media item. During this transition, `Player.EVENT_VIDEO_SIZE_CHANGED` fired with video size (0, 0), causing `getVideoBasedOrientation()` to return `SCREEN_ORIENTATION_UNSPECIFIED`, which allowed the device to auto-rotate to portrait.

**Fix:** Changed `getVideoBasedOrientation()` to return the current `activity.requestedOrientation` instead of `UNSPECIFIED` when video size is (0, 0), preserving the existing orientation during transient states.

### Bug 2: Playback speed reset to 1.0x
**Root cause:** The same media item replacement triggered `onPlaybackStateChanged(STATE_IDLE)`, which called `setPlaybackSpeed(defaultPlaybackSpeed)` (1.0x), overwriting the user's custom speed.

**Fix:** Replaced the disruptive `addMediaItem`/`seekTo`/`removeMediaItem` pattern with `replaceMediaItem()`, and explicitly restored the playback speed after replacement.

### Files changed
- `feature/player/src/main/java/.../extensions/Player.kt` - Use `replaceMediaItem` + restore speed
- `feature/player/src/main/java/.../state/RotationState.kt` - Preserve orientation when video size is (0,0)
