### PR TITLE
feat(player): video chapters & bookmarks with per-video persistence

### DIFF
--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/mappers/ToVideoState.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/mappers/ToVideoState.kt
@@ -3,6 +3,7 @@ package dev.anilbeesetti.nextplayer.core.data.mappers
 import dev.anilbeesetti.nextplayer.core.data.models.VideoState
 import dev.anilbeesetti.nextplayer.core.database.converter.UriListConverter
 import dev.anilbeesetti.nextplayer.core.database.entities.MediumStateEntity
+import dev.anilbeesetti.nextplayer.core.model.ChapterListConverter
 
 fun MediumStateEntity.toVideoState(): VideoState {
     return VideoState(
@@ -15,5 +16,6 @@ fun MediumStateEntity.toVideoState(): VideoState {
         videoScale = videoScale,
         subtitleDelayMilliseconds = subtitleDelayMilliseconds,
         subtitleSpeed = subtitleSpeed,
+        chapters = ChapterListConverter.fromStringToList(chapters),
     )
 }

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/models/VideoState.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/models/VideoState.kt
@@ -1,6 +1,7 @@
 package dev.anilbeesetti.nextplayer.core.data.models
 
 import android.net.Uri
+import dev.anilbeesetti.nextplayer.core.model.Chapter
 
 data class VideoState(
     val path: String,
@@ -12,4 +13,5 @@ data class VideoState(
     val videoScale: Float,
     val subtitleDelayMilliseconds: Long,
     val subtitleSpeed: Float,
+    val chapters: List<Chapter>,
 )

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalMediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalMediaRepository.kt
@@ -12,6 +12,8 @@ import dev.anilbeesetti.nextplayer.core.database.dao.MediumStateDao
 import dev.anilbeesetti.nextplayer.core.database.entities.MediumStateEntity
 import dev.anilbeesetti.nextplayer.core.database.relations.DirectoryWithMedia
 import dev.anilbeesetti.nextplayer.core.database.relations.MediumWithInfo
+import dev.anilbeesetti.nextplayer.core.model.Chapter
+import dev.anilbeesetti.nextplayer.core.model.ChapterListConverter
 import dev.anilbeesetti.nextplayer.core.model.Folder
 import dev.anilbeesetti.nextplayer.core.model.Video
 import javax.inject.Inject
@@ -42,6 +44,12 @@ class LocalMediaRepository @Inject constructor(
 
     override suspend fun getVideoState(uri: String): VideoState? {
         return mediumStateDao.get(uri)?.toVideoState()
+    }
+
+    override fun getChaptersStream(uri: String): Flow<List<Chapter>> {
+        return mediumStateDao.getAsFlow(uri).map { state ->
+            ChapterListConverter.fromStringToList(state?.chapters ?: "")
+        }
     }
 
     override suspend fun updateMediumLastPlayedTime(uri: String, lastPlayedTime: Long) {
@@ -140,6 +148,17 @@ class LocalMediaRepository @Inject constructor(
         mediumStateDao.upsert(
             mediumState = stateEntity.copy(
                 subtitleSpeed = speed,
+                lastPlayedTime = System.currentTimeMillis(),
+            ),
+        )
+    }
+
+    override suspend fun updateChapters(uri: String, chapters: List<Chapter>) {
+        val stateEntity = mediumStateDao.get(uri) ?: MediumStateEntity(uriString = uri)
+
+        mediumStateDao.upsert(
+            mediumState = stateEntity.copy(
+                chapters = ChapterListConverter.fromListToString(chapters),
                 lastPlayedTime = System.currentTimeMillis(),
             ),
         )

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/MediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/MediaRepository.kt
@@ -2,6 +2,7 @@ package dev.anilbeesetti.nextplayer.core.data.repository
 
 import android.net.Uri
 import dev.anilbeesetti.nextplayer.core.data.models.VideoState
+import dev.anilbeesetti.nextplayer.core.model.Chapter
 import dev.anilbeesetti.nextplayer.core.model.Folder
 import dev.anilbeesetti.nextplayer.core.model.Video
 import kotlinx.coroutines.flow.Flow
@@ -13,6 +14,7 @@ interface MediaRepository {
 
     suspend fun getVideoByUri(uri: String): Video?
     suspend fun getVideoState(uri: String): VideoState?
+    fun getChaptersStream(uri: String): Flow<List<Chapter>>
 
     suspend fun updateMediumLastPlayedTime(uri: String, lastPlayedTime: Long)
     suspend fun updateMediumPosition(uri: String, position: Long)
@@ -23,4 +25,5 @@ interface MediaRepository {
     suspend fun addExternalSubtitleToMedium(uri: String, subtitleUri: Uri)
     suspend fun updateSubtitleDelay(uri: String, delay: Long)
     suspend fun updateSubtitleSpeed(uri: String, speed: Float)
+    suspend fun updateChapters(uri: String, chapters: List<Chapter>)
 }

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/fake/FakeMediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/fake/FakeMediaRepository.kt
@@ -3,6 +3,7 @@ package dev.anilbeesetti.nextplayer.core.data.repository.fake
 import android.net.Uri
 import dev.anilbeesetti.nextplayer.core.data.models.VideoState
 import dev.anilbeesetti.nextplayer.core.data.repository.MediaRepository
+import dev.anilbeesetti.nextplayer.core.model.Chapter
 import dev.anilbeesetti.nextplayer.core.model.Folder
 import dev.anilbeesetti.nextplayer.core.model.Video
 import kotlinx.coroutines.flow.Flow
@@ -33,6 +34,10 @@ class FakeMediaRepository : MediaRepository {
         return null
     }
 
+    override fun getChaptersStream(uri: String): Flow<List<Chapter>> {
+        return flowOf(emptyList())
+    }
+
     override suspend fun updateMediumLastPlayedTime(uri: String, lastPlayedTime: Long) {
     }
 
@@ -58,5 +63,8 @@ class FakeMediaRepository : MediaRepository {
     }
 
     override suspend fun updateSubtitleSpeed(uri: String, speed: Float) {
+    }
+
+    override suspend fun updateChapters(uri: String, chapters: List<Chapter>) {
     }
 }

--- a/core/database/schemas/dev.anilbeesetti.nextplayer.core.database.MediaDatabase/5.json
+++ b/core/database/schemas/dev.anilbeesetti.nextplayer.core.database.MediaDatabase/5.json
@@ -1,0 +1,467 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "76566acc372b22759a2a89ca0d318370",
+    "entities": [
+      {
+        "tableName": "directories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`path` TEXT NOT NULL, `filename` TEXT NOT NULL, `last_modified` INTEGER NOT NULL, `parent_path` TEXT, PRIMARY KEY(`path`))",
+        "fields": [
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "last_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentPath",
+            "columnName": "parent_path",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "path"
+          ]
+        }
+      },
+      {
+        "tableName": "media",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uri` TEXT NOT NULL, `path` TEXT NOT NULL, `filename` TEXT NOT NULL, `parent_path` TEXT NOT NULL, `last_modified` INTEGER NOT NULL, `size` INTEGER NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `media_store_id` INTEGER NOT NULL, `format` TEXT, `thumbnail_path` TEXT, PRIMARY KEY(`uri`))",
+        "fields": [
+          {
+            "fieldPath": "uriString",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "filename",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentPath",
+            "columnName": "parent_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modified",
+            "columnName": "last_modified",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediaStoreId",
+            "columnName": "media_store_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailPath",
+            "columnName": "thumbnail_path",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_uri",
+            "unique": true,
+            "columnNames": [
+              "uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_media_uri` ON `${TABLE_NAME}` (`uri`)"
+          },
+          {
+            "name": "index_media_path",
+            "unique": false,
+            "columnNames": [
+              "path"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_media_path` ON `${TABLE_NAME}` (`path`)"
+          }
+        ]
+      },
+      {
+        "tableName": "media_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uri` TEXT NOT NULL, `playback_position` INTEGER NOT NULL, `audio_track_index` INTEGER, `subtitle_track_index` INTEGER, `playback_speed` REAL, `last_played_time` INTEGER, `external_subs` TEXT NOT NULL, `video_scale` REAL NOT NULL, `subtitle_delay` INTEGER NOT NULL, `subtitle_speed` REAL NOT NULL, `chapters` TEXT NOT NULL, PRIMARY KEY(`uri`))",
+        "fields": [
+          {
+            "fieldPath": "uriString",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackPosition",
+            "columnName": "playback_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioTrackIndex",
+            "columnName": "audio_track_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "subtitleTrackIndex",
+            "columnName": "subtitle_track_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playback_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lastPlayedTime",
+            "columnName": "last_played_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalSubs",
+            "columnName": "external_subs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoScale",
+            "columnName": "video_scale",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitleDelayMilliseconds",
+            "columnName": "subtitle_delay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitleSpeed",
+            "columnName": "subtitle_speed",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chapters",
+            "columnName": "chapters",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_state_uri",
+            "unique": true,
+            "columnNames": [
+              "uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_media_state_uri` ON `${TABLE_NAME}` (`uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "video_stream_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_index` INTEGER NOT NULL, `title` TEXT, `codec_name` TEXT NOT NULL, `language` TEXT, `disposition` INTEGER NOT NULL, `bit_rate` INTEGER NOT NULL, `frame_rate` REAL NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `medium_uri` TEXT NOT NULL, PRIMARY KEY(`medium_uri`, `stream_index`), FOREIGN KEY(`medium_uri`) REFERENCES `media`(`uri`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "stream_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "codecName",
+            "columnName": "codec_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "disposition",
+            "columnName": "disposition",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bit_rate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frameRate",
+            "columnName": "frame_rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frameWidth",
+            "columnName": "width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "frameHeight",
+            "columnName": "height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediumUri",
+            "columnName": "medium_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "medium_uri",
+            "stream_index"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "medium_uri"
+            ],
+            "referencedColumns": [
+              "uri"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "audio_stream_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_index` INTEGER NOT NULL, `title` TEXT, `codec_name` TEXT NOT NULL, `language` TEXT, `disposition` INTEGER NOT NULL, `bit_rate` INTEGER NOT NULL, `sample_format` TEXT, `sample_rate` INTEGER NOT NULL, `channels` INTEGER NOT NULL, `channel_layout` TEXT, `medium_uri` TEXT NOT NULL, PRIMARY KEY(`medium_uri`, `stream_index`), FOREIGN KEY(`medium_uri`) REFERENCES `media`(`uri`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "stream_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "codecName",
+            "columnName": "codec_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "disposition",
+            "columnName": "disposition",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitRate",
+            "columnName": "bit_rate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleFormat",
+            "columnName": "sample_format",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sample_rate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channels",
+            "columnName": "channels",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelLayout",
+            "columnName": "channel_layout",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mediumUri",
+            "columnName": "medium_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "medium_uri",
+            "stream_index"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "medium_uri"
+            ],
+            "referencedColumns": [
+              "uri"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "subtitle_stream_info",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stream_index` INTEGER NOT NULL, `title` TEXT, `codec_name` TEXT NOT NULL, `language` TEXT, `disposition` INTEGER NOT NULL, `medium_uri` TEXT NOT NULL, PRIMARY KEY(`medium_uri`, `stream_index`), FOREIGN KEY(`medium_uri`) REFERENCES `media`(`uri`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "index",
+            "columnName": "stream_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "codecName",
+            "columnName": "codec_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "disposition",
+            "columnName": "disposition",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediumUri",
+            "columnName": "medium_uri",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "medium_uri",
+            "stream_index"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "media",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "medium_uri"
+            ],
+            "referencedColumns": [
+              "uri"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '76566acc372b22759a2a89ca0d318370')"
+    ]
+  }
+}

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/DatabaseModule.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/DatabaseModule.kt
@@ -22,7 +22,12 @@ object DatabaseModule {
         klass = MediaDatabase::class.java,
         name = MediaDatabase.DATABASE_NAME,
     ).apply {
-        addMigrations(MediaDatabase.MIGRATION_1_2, MediaDatabase.MIGRATION_2_3, MediaDatabase.MIGRATION_3_4)
+        addMigrations(
+            MediaDatabase.MIGRATION_1_2,
+            MediaDatabase.MIGRATION_2_3,
+            MediaDatabase.MIGRATION_3_4,
+            MediaDatabase.MIGRATION_4_5,
+        )
         fallbackToDestructiveMigration(false)
     }.build()
 }

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/MediaDatabase.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/MediaDatabase.kt
@@ -23,7 +23,7 @@ import dev.anilbeesetti.nextplayer.core.database.entities.VideoStreamInfoEntity
         AudioStreamInfoEntity::class,
         SubtitleStreamInfoEntity::class,
     ],
-    version = 4,
+    version = 5,
     exportSchema = true,
 )
 abstract class MediaDatabase : RoomDatabase() {
@@ -182,6 +182,12 @@ abstract class MediaDatabase : RoomDatabase() {
             override fun migrate(db: SupportSQLiteDatabase) {
                 db.execSQL("ALTER TABLE `media_state` ADD COLUMN `subtitle_delay` INTEGER NOT NULL DEFAULT 0")
                 db.execSQL("ALTER TABLE `media_state` ADD COLUMN `subtitle_speed` REAL NOT NULL DEFAULT 1")
+            }
+        }
+
+        val MIGRATION_4_5 = object : Migration(4, 5) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `media_state` ADD COLUMN `chapters` TEXT NOT NULL DEFAULT ''")
             }
         }
     }

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/entities/MediumStateEntity.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/entities/MediumStateEntity.kt
@@ -33,4 +33,6 @@ data class MediumStateEntity(
     val subtitleDelayMilliseconds: Long = 0,
     @ColumnInfo(name = "subtitle_speed")
     val subtitleSpeed: Float = 1f,
+    @ColumnInfo(name = "chapters")
+    val chapters: String = "",
 )

--- a/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/Chapter.kt
+++ b/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/Chapter.kt
@@ -1,0 +1,36 @@
+package dev.anilbeesetti.nextplayer.core.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * A user-defined chapter / bookmark within a video, identified by a [title] and the
+ * playback position [timestampMs] it points to. Stored per-video and importable/exportable
+ * as a JSON array of these objects.
+ */
+@Serializable
+data class Chapter(
+    val title: String,
+    val timestampMs: Long,
+)
+
+/**
+ * Serializes a list of [Chapter]s to/from a JSON string for both DB persistence and
+ * file import/export. Kept here in `core:model` so callers do not need a direct
+ * kotlinx-serialization dependency. Mirrors the role of `UriListConverter`.
+ */
+object ChapterListConverter {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun fromListToString(chapters: List<Chapter>): String {
+        if (chapters.isEmpty()) return ""
+        return json.encodeToString(chapters)
+    }
+
+    fun fromStringToList(value: String): List<Chapter> {
+        if (value.isBlank()) return emptyList()
+        return runCatching { json.decodeFromString<List<Chapter>>(value) }
+            .getOrDefault(emptyList())
+    }
+}

--- a/core/ui/src/main/res/drawable/ic_chapters.xml
+++ b/core/ui/src/main/res/drawable/ic_chapters.xml
@@ -1,0 +1,3 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+    <path android:fillColor="@android:color/white" android:pathData="M3,3h18c1.1,0 2,0.9 2,2v14c0,1.1 -0.9,2 -2,2H3c-1.1,0 -2,-0.9 -2,-2V5c0,-1.1 0.9,-2 2,-2zm0,2v14h18V5H3zm2,3h14v2H5V8zm0,4h14v2H5v-2zm0,4h14v2H5v-2z"/>
+</vector>

--- a/core/ui/src/main/res/drawable/ic_export.xml
+++ b/core/ui/src/main/res/drawable/ic_export.xml
@@ -1,0 +1,3 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+    <path android:fillColor="@android:color/white" android:pathData="M5,20h14v-2H5v2zm7,-18l-5,5h3v4h4v-4h3l-5,-5z"/>
+</vector>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -301,4 +301,12 @@
     <string name="thumbnail_setting_change_confirmation">Changing this setting will clear the thumbnail cache. Thumbnails will be generated again when media list is opened. Continue?</string>
     <string name="material_you_controls">Material You controls</string>
     <string name="material_you_controls_description">Use material you style controls</string>
+    <string name="chapters">Chapters</string>
+    <string name="add_bookmark">Add bookmark</string>
+    <string name="import_chapters">Import</string>
+    <string name="export_chapters">Export</string>
+    <string name="no_chapters">No chapters yet. Add a bookmark at the current position, or import a chapters file.</string>
+    <string name="bookmark_added">Bookmark added</string>
+    <string name="chapters_exported">Chapters exported</string>
+    <string name="invalid_chapters_file">Could not read chapters from that file</string>
 </resources>

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/MediaPlayerScreen.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/MediaPlayerScreen.kt
@@ -63,6 +63,7 @@ import dev.anilbeesetti.nextplayer.feature.player.buttons.PreviousButton
 import dev.anilbeesetti.nextplayer.feature.player.state.ControlsVisibilityState
 import dev.anilbeesetti.nextplayer.feature.player.state.VerticalGesture
 import dev.anilbeesetti.nextplayer.feature.player.state.rememberBrightnessState
+import dev.anilbeesetti.nextplayer.feature.player.state.rememberChaptersState
 import dev.anilbeesetti.nextplayer.feature.player.state.rememberControlsVisibilityState
 import dev.anilbeesetti.nextplayer.feature.player.state.rememberErrorState
 import dev.anilbeesetti.nextplayer.feature.player.state.rememberMediaPresentationState
@@ -147,6 +148,7 @@ fun MediaPlayerScreen(
         screenOrientation = playerPreferences.playerScreenOrientation,
     )
     val errorState = rememberErrorState(player = player)
+    val chaptersState = rememberChaptersState(player = player, viewModel = viewModel)
 
     LaunchedEffect(pictureInPictureState.isInPictureInPictureMode) {
         if (pictureInPictureState.isInPictureInPictureMode) {
@@ -320,6 +322,14 @@ fun MediaPlayerScreen(
                                     onSeekEnd = seekGestureState::onSeekEnd,
                                     onRotateClick = rotationState::rotate,
                                     onPlayInBackgroundClick = onPlayInBackgroundClick,
+                                    onChaptersClick = {
+                                        controlsVisibilityState.hideControls()
+                                        overlayView = OverlayView.CHAPTERS
+                                    },
+                                    onAddBookmark = {
+                                        chaptersState.addBookmarkAtCurrentPosition()
+                                        Toast.makeText(context, coreUiR.string.bookmark_added, Toast.LENGTH_SHORT).show()
+                                    },
                                     onLockControlsClick = {
                                         controlsVisibilityState.showControls()
                                         controlsVisibilityState.lockControls()
@@ -385,6 +395,7 @@ fun MediaPlayerScreen(
                 player = player,
                 overlayView = overlayView,
                 videoContentScale = videoZoomAndContentScaleState.videoContentScale,
+                chaptersState = chaptersState,
                 onDismiss = { overlayView = null },
                 onSelectSubtitleClick = onSelectSubtitleClick,
                 onSubtitleOptionEvent = viewModel::onSubtitleOptionEvent,

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerViewModel.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dev.anilbeesetti.nextplayer.core.data.repository.MediaRepository
 import dev.anilbeesetti.nextplayer.core.data.repository.PreferencesRepository
 import dev.anilbeesetti.nextplayer.core.domain.GetSortedPlaylistUseCase
+import dev.anilbeesetti.nextplayer.core.model.Chapter
 import dev.anilbeesetti.nextplayer.core.model.LoopMode
 import dev.anilbeesetti.nextplayer.core.model.PlayerPreferences
 import dev.anilbeesetti.nextplayer.core.model.Video
@@ -15,6 +16,7 @@ import dev.anilbeesetti.nextplayer.core.model.VideoContentScale
 import dev.anilbeesetti.nextplayer.feature.player.state.SubtitleOptionsEvent
 import dev.anilbeesetti.nextplayer.feature.player.state.VideoZoomEvent
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -103,6 +105,14 @@ class PlayerViewModel @Inject constructor(
     private fun updateSubtitleSpeed(uri: String, speed: Float) {
         viewModelScope.launch {
             mediaRepository.updateSubtitleSpeed(uri, speed)
+        }
+    }
+
+    fun chaptersFlow(uri: String): Flow<List<Chapter>> = mediaRepository.getChaptersStream(uri)
+
+    fun updateChapters(uri: String, chapters: List<Chapter>) {
+        viewModelScope.launch {
+            mediaRepository.updateChapters(uri, chapters)
         }
     }
 }

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/state/ChaptersState.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/state/ChaptersState.kt
@@ -1,0 +1,74 @@
+package dev.anilbeesetti.nextplayer.feature.player.state
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.media3.common.Player
+import androidx.media3.common.listen
+import dev.anilbeesetti.nextplayer.core.common.Utils
+import dev.anilbeesetti.nextplayer.core.model.Chapter
+import dev.anilbeesetti.nextplayer.feature.player.PlayerViewModel
+import kotlinx.coroutines.flow.flowOf
+
+/**
+ * Holds the chapter/bookmark list for the currently playing item and the actions that
+ * mutate it. Chapters are persisted per-video through [PlayerViewModel.updateChapters] and
+ * observed live via [PlayerViewModel.chaptersFlow], re-keyed whenever the media item changes.
+ */
+@Composable
+fun rememberChaptersState(player: Player, viewModel: PlayerViewModel): ChaptersState {
+    var mediaId by remember { mutableStateOf(player.currentMediaItem?.mediaId) }
+    LaunchedEffect(player) {
+        player.listen { events ->
+            if (events.containsAny(Player.EVENT_MEDIA_ITEM_TRANSITION)) {
+                mediaId = player.currentMediaItem?.mediaId
+            }
+        }
+    }
+    val chapters by remember(mediaId) {
+        mediaId?.let(viewModel::chaptersFlow) ?: flowOf(emptyList<Chapter>())
+    }.collectAsState(initial = emptyList())
+
+    return ChaptersState(
+        chapters = chapters,
+        uri = mediaId,
+        player = player,
+        onUpdate = viewModel::updateChapters,
+    )
+}
+
+class ChaptersState(
+    val chapters: List<Chapter>,
+    private val uri: String?,
+    private val player: Player,
+    private val onUpdate: (uri: String, chapters: List<Chapter>) -> Unit,
+) {
+    fun seekTo(timestampMs: Long) {
+        player.seekTo(timestampMs)
+    }
+
+    fun addBookmarkAtCurrentPosition() {
+        val u = uri ?: return
+        val position = player.currentPosition.coerceAtLeast(0L)
+        val bookmark = Chapter(title = Utils.formatDurationMillis(position), timestampMs = position)
+        onUpdate(u, (chapters + bookmark).sortedBy { it.timestampMs })
+    }
+
+    fun importChapters(imported: List<Chapter>) {
+        val u = uri ?: return
+        if (imported.isEmpty()) return
+        val merged = (chapters + imported)
+            .distinctBy { it.timestampMs to it.title }
+            .sortedBy { it.timestampMs }
+        onUpdate(u, merged)
+    }
+
+    fun removeChapter(chapter: Chapter) {
+        val u = uri ?: return
+        onUpdate(u, chapters - chapter)
+    }
+}

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/ChaptersSelectorView.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/ChaptersSelectorView.kt
@@ -1,0 +1,183 @@
+package dev.anilbeesetti.nextplayer.feature.player.ui
+
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.anilbeesetti.nextplayer.core.common.Utils
+import dev.anilbeesetti.nextplayer.core.model.Chapter
+import dev.anilbeesetti.nextplayer.core.model.ChapterListConverter
+import dev.anilbeesetti.nextplayer.core.ui.R
+import dev.anilbeesetti.nextplayer.feature.player.state.ChaptersState
+
+@Composable
+fun BoxScope.ChaptersSelectorView(
+    modifier: Modifier = Modifier,
+    show: Boolean,
+    chaptersState: ChaptersState,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val chapters = chaptersState.chapters
+
+    val importLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        val text = runCatching {
+            context.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+        }.getOrNull()
+        val imported = text?.let { ChapterListConverter.fromStringToList(it) }.orEmpty()
+        if (imported.isEmpty()) {
+            Toast.makeText(context, R.string.invalid_chapters_file, Toast.LENGTH_SHORT).show()
+        } else {
+            chaptersState.importChapters(imported)
+        }
+    }
+
+    val exportLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument("application/json"),
+    ) { uri ->
+        if (uri == null) return@rememberLauncherForActivityResult
+        runCatching {
+            context.contentResolver.openOutputStream(uri)?.use { out ->
+                out.write(ChapterListConverter.fromListToString(chapters).toByteArray())
+            }
+        }
+        Toast.makeText(context, R.string.chapters_exported, Toast.LENGTH_SHORT).show()
+    }
+
+    OverlayView(
+        modifier = modifier,
+        show = show,
+        title = stringResource(R.string.chapters),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            FilledTonalIconButton(onClick = { chaptersState.addBookmarkAtCurrentPosition() }) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_add),
+                    contentDescription = stringResource(R.string.add_bookmark),
+                )
+            }
+            IconButton(onClick = { importLauncher.launch(arrayOf("application/json", "text/plain", "*/*")) }) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_chapters),
+                    contentDescription = stringResource(R.string.import_chapters),
+                )
+            }
+            IconButton(
+                onClick = { if (chapters.isNotEmpty()) exportLauncher.launch("chapters.json") },
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_export),
+                    contentDescription = stringResource(R.string.export_chapters),
+                )
+            }
+        }
+
+        if (chapters.isEmpty()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = stringResource(R.string.no_chapters),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                items(
+                    items = chapters,
+                    key = { "${it.timestampMs}:${it.title}" },
+                ) { chapter ->
+                    ChapterRow(
+                        chapter = chapter,
+                        onClick = {
+                            chaptersState.seekTo(chapter.timestampMs)
+                            onDismiss()
+                        },
+                        onDelete = { chaptersState.removeChapter(chapter) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChapterRow(
+    chapter: Chapter,
+    onClick: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(MaterialTheme.shapes.medium)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = Utils.formatDurationMillis(chapter.timestampMs),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = chapter.title,
+            style = MaterialTheme.typography.bodyLarge,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        IconButton(onClick = onDelete) {
+            Icon(
+                painter = painterResource(R.drawable.ic_close),
+                contentDescription = stringResource(R.string.remove),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/OverlayShowView.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/OverlayShowView.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.Modifier
 import androidx.media3.common.Player
 import dev.anilbeesetti.nextplayer.core.model.VideoContentScale
 import dev.anilbeesetti.nextplayer.feature.player.extensions.noRippleClickable
+import dev.anilbeesetti.nextplayer.feature.player.state.ChaptersState
 import dev.anilbeesetti.nextplayer.feature.player.state.SubtitleOptionsEvent
 
 @Composable
@@ -15,6 +16,7 @@ fun BoxScope.OverlayShowView(
     player: Player,
     overlayView: OverlayView?,
     videoContentScale: VideoContentScale,
+    chaptersState: ChaptersState,
     onDismiss: () -> Unit = {},
     onSelectSubtitleClick: () -> Unit = {},
     onSubtitleOptionEvent: (SubtitleOptionsEvent) -> Unit = {},
@@ -62,6 +64,12 @@ fun BoxScope.OverlayShowView(
         show = overlayView == OverlayView.PLAYLIST,
         player = player,
     )
+
+    ChaptersSelectorView(
+        show = overlayView == OverlayView.CHAPTERS,
+        chaptersState = chaptersState,
+        onDismiss = onDismiss,
+    )
 }
 
 val Configuration.isPortrait: Boolean
@@ -73,4 +81,5 @@ enum class OverlayView {
     PLAYBACK_SPEED,
     VIDEO_CONTENT_SCALE,
     PLAYLIST,
+    CHAPTERS,
 }

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/controls/ControlsBottomView.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/controls/ControlsBottomView.kt
@@ -81,6 +81,8 @@ fun ControlsBottomView(
     onPictureInPictureClick: () -> Unit,
     onRotateClick: () -> Unit,
     onPlayInBackgroundClick: () -> Unit,
+    onChaptersClick: () -> Unit,
+    onAddBookmark: () -> Unit,
     onSeek: (Long) -> Unit,
     onSeekEnd: () -> Unit,
 ) {
@@ -176,6 +178,15 @@ fun ControlsBottomView(
             PlayerButton(onClick = onPlayInBackgroundClick) {
                 Icon(
                     painter = painterResource(R.drawable.ic_headset),
+                    contentDescription = null,
+                )
+            }
+            PlayerButton(
+                onClick = onChaptersClick,
+                onLongClick = onAddBookmark,
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.ic_chapters),
                     contentDescription = null,
                 )
             }


### PR DESCRIPTION
## Summary

Adds a **Chapters / bookmarks** feature to the player, built on the current Jetpack Compose UI.

This supersedes #1146, which was written against the old XML / view-binding player and is no longer mergeable after the Compose rewrite — every layout it modified (`exo_player_control_view.xml`, `bottom_sheet_sections.xml`, …) has since been removed. I re-implemented the feature from scratch following the patterns already used by the existing selector panels.

### What it does
- A **Chapters** button in the bottom player controls:
  - **Tap** → opens a chapters panel (same overlay style as the playback-speed / playlist selectors).
  - **Long-press** → adds a bookmark at the current position.
- In the panel you can tap an entry to **seek** to it, **add** a bookmark, **import** a chapters file, or **export** the current list. Entries are simple `{ "title": String, "timestampMs": Long }` JSON objects.
- Chapters are **persisted per video** in the existing Room `media_state` table, so they survive reopening the file.

### Implementation
- New `Chapter` model + `ChapterListConverter` in `core:model` (kotlinx-serialization, already a dependency there — keeps other modules dependency-free).
- `media_state` gains a `chapters` TEXT column; **DB version 4 → 5** with an additive, non-destructive `MIGRATION_4_5`. Generated `5.json` schema is included.
- `MediaRepository` gains `updateChapters` / `getChaptersStream`, using the same read-copy-upsert pattern as the other per-video state.
- UI follows the existing selector convention: `OverlayView.CHAPTERS` + `ChaptersSelectorView` + a `rememberChaptersState` holder, plus one `PlayerButton` in `ControlsBottomView`.
- No new dependencies and no DI-graph changes beyond the added repository method.

### Testing
- Builds clean — `./gradlew :app:assembleDebug` passes (Room v4→5 KSP, Hilt, resource linking and packaging all succeed).
- On-device verification of the full flow (add → seek → import/export → persistence across reopen) is in progress.

Happy to adjust the button placement, naming, or the import/export format to match your preferences. Supersedes #1146.
