### PR TITLE
feat: add option to hide folder duration separately

### DIFF
--- a/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/ApplicationPreferences.kt
+++ b/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/ApplicationPreferences.kt
@@ -16,6 +16,7 @@ data class ApplicationPreferences(
 
     // Fields
     val showDurationField: Boolean = true,
+    val showFolderDurationField: Boolean = true,
     val showExtensionField: Boolean = false,
     val showPathField: Boolean = true,
     val showResolutionField: Boolean = false,

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="grant_permission">Grant Permission</string>
     <string name="group_videos">Group videos by folder</string>
     <string name="duration">Duration</string>
+    <string name="folder_duration">Folder duration</string>
     <string name="location">Location</string>
     <string name="menu">Menu</string>
     <string name="navigate_up">Navigate up</string>

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/FolderItem.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/FolderItem.kt
@@ -121,7 +121,7 @@ private fun FolderListItem(
                         .aspectRatio(20 / 17f),
                 )
 
-                if (preferences.showDurationField) {
+                if (preferences.showFolderDurationField) {
                     InfoChip(
                         text = Utils.formatDurationMillis(folder.totalDuration),
                         modifier = Modifier
@@ -231,7 +231,7 @@ private fun FolderGridItem(
                             .aspectRatio(20 / 17f),
                     )
 
-                    if (preferences.showDurationField) {
+                    if (preferences.showFolderDurationField) {
                         InfoChip(
                             text = Utils.formatDurationMillis(folder.totalDuration),
                             modifier = Modifier

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/QuickSettingsDialog.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/QuickSettingsDialog.kt
@@ -147,6 +147,11 @@ fun QuickSettingsDialog(
                         onClick = { preferences = preferences.copy(showDurationField = !preferences.showDurationField) },
                     )
                     FieldChip(
+                        label = stringResource(id = R.string.folder_duration),
+                        selected = preferences.showFolderDurationField,
+                        onClick = { preferences = preferences.copy(showFolderDurationField = !preferences.showFolderDurationField) },
+                    )
+                    FieldChip(
                         label = stringResource(id = R.string.extension),
                         selected = preferences.showExtensionField,
                         onClick = { preferences = preferences.copy(showExtensionField = !preferences.showExtensionField) },


### PR DESCRIPTION
Hey! 👋
So I added a small new toggle called "Folder duration" under Quick Settings → Fields.
Right now the existing Duration toggle hides the duration from both videos and folders together. I wanted a way to hide just the folder duration and keep it showing on videos — mainly for a cleaner look on the folder list, personal preference thing 😅
Issue #1744 

What changed:
Added a new toggle to hide Folder duration in Quick Settings 
It only affects folders, videos stay the same

Totally understand if this feels like a niche addition or you don't want another toggle cluttering the Fields section — no hard feelings at all if you'd rather not merge it! Just thought I'd share it in case it's useful for others too. Let me know what you think 🙂

<img width="1272" height="1884" alt="ref1" src="https://github.com/user-attachments/assets/8e8fa361-0da7-4e52-83d4-2a4ba9a84f8a" />
<img width="1272" height="2800" alt="ref2" src="https://github.com/user-attachments/assets/79b4c19d-5ffd-40b8-89dd-695da7fd25fa" />
