### PR TITLE
Fix MediaStore delete request crashes

### DIFF
--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsService.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsService.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import android.provider.BaseColumns
 import android.provider.DocumentsContract
 import android.provider.MediaStore
 import android.webkit.MimeTypeMap
@@ -284,13 +285,30 @@ class LocalMediaOperationsService @Inject constructor(
     }
 
     @RequiresApi(Build.VERSION_CODES.R)
-    private suspend fun deleteMediaR(uris: List<Uri>): Boolean = suspendCancellableCoroutine { continuation ->
+    private suspend fun deleteMediaR(uris: List<Uri>): Boolean = runMediaRequests(
+        items = uris,
+        itemExists = ::mediaExists,
+        request = ::requestDeleteR,
+    )
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private suspend fun requestDeleteR(uris: List<Uri>): Boolean = suspendCancellableCoroutine { continuation ->
         launchDeleteRequest(
             uris = uris,
             onResultOk = { continuation.resume(true) },
             onResultCanceled = { continuation.resume(false) },
         )
     }
+
+    private fun mediaExists(uri: Uri): Boolean = runCatching {
+        contentResolver.query(
+            uri,
+            arrayOf(BaseColumns._ID),
+            null,
+            null,
+            null,
+        )?.use { cursor -> cursor.moveToFirst() } == true
+    }.getOrDefault(false)
 
     private suspend fun deleteMediaBelowR(uris: List<Uri>): Boolean {
         return uris.map { uri ->

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaRequestRunner.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaRequestRunner.kt
@@ -1,0 +1,35 @@
+package dev.anilbeesetti.nextplayer.core.media.services
+
+internal const val MAX_MEDIA_REQUEST_URIS = 2_000
+
+internal suspend fun <T> runMediaRequests(
+    items: List<T>,
+    maxBatchSize: Int = MAX_MEDIA_REQUEST_URIS,
+    itemExists: suspend (T) -> Boolean,
+    request: suspend (List<T>) -> Boolean,
+): Boolean {
+    require(maxBatchSize > 0)
+
+    for (batch in items.distinct().chunked(maxBatchSize)) {
+        if (!runMediaRequestBatch(batch, itemExists, request)) return false
+    }
+    return true
+}
+
+private suspend fun <T> runMediaRequestBatch(
+    batch: List<T>,
+    itemExists: suspend (T) -> Boolean,
+    request: suspend (List<T>) -> Boolean,
+): Boolean {
+    var candidates = batch
+    while (candidates.isNotEmpty()) {
+        try {
+            return request(candidates)
+        } catch (_: IllegalArgumentException) {
+            val existingItems = candidates.filter { itemExists(it) }
+            if (existingItems.size == candidates.size) return false
+            candidates = existingItems
+        }
+    }
+    return true
+}

--- a/core/media/src/test/java/dev/anilbeesetti/nextplayer/core/media/services/MediaRequestRunnerTest.kt
+++ b/core/media/src/test/java/dev/anilbeesetti/nextplayer/core/media/services/MediaRequestRunnerTest.kt
@@ -1,0 +1,90 @@
+package dev.anilbeesetti.nextplayer.core.media.services
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MediaRequestRunnerTest {
+
+    @Test
+    fun `splits requests at the platform uri limit`() = runBlocking {
+        val requestedBatchSizes = mutableListOf<Int>()
+
+        val result = runMediaRequests(
+            items = (1..2_001).toList(),
+            maxBatchSize = 2_000,
+            itemExists = { true },
+            request = { batch ->
+                require(batch.size <= 2_000)
+                requestedBatchSizes += batch.size
+                true
+            },
+        )
+
+        assertTrue(result)
+        assertEquals(listOf(2_000, 1), requestedBatchSizes)
+    }
+
+    @Test
+    fun `retries without an item that disappeared before request creation`() = runBlocking {
+        val requestedBatches = mutableListOf<List<String>>()
+
+        val result = runMediaRequests(
+            items = listOf("existing", "stale"),
+            maxBatchSize = 2_000,
+            itemExists = { it == "existing" },
+            request = { batch ->
+                requestedBatches += batch
+                if ("stale" in batch) throw IllegalArgumentException("URI no longer exists")
+                true
+            },
+        )
+
+        assertTrue(result)
+        assertEquals(
+            listOf(
+                listOf("existing", "stale"),
+                listOf("existing"),
+            ),
+            requestedBatches,
+        )
+    }
+
+    @Test
+    fun `treats items already deleted by another app as success`() = runBlocking {
+        var requestCount = 0
+
+        val result = runMediaRequests(
+            items = listOf("stale"),
+            maxBatchSize = 2_000,
+            itemExists = { false },
+            request = {
+                requestCount++
+                throw IllegalArgumentException("URI no longer exists")
+            },
+        )
+
+        assertTrue(result)
+        assertEquals(1, requestCount)
+    }
+
+    @Test
+    fun `returns failure when illegal argument is not caused by stale items`() = runBlocking {
+        var requestCount = 0
+
+        val result = runMediaRequests(
+            items = listOf("existing"),
+            maxBatchSize = 2_000,
+            itemExists = { true },
+            request = {
+                requestCount++
+                throw IllegalArgumentException("Unrelated provider rejection")
+            },
+        )
+
+        assertFalse(result)
+        assertEquals(1, requestCount)
+    }
+}


### PR DESCRIPTION
## Summary
- batch MediaStore delete requests at the 2,000 URI platform limit
- retry request creation after filtering media rows that disappeared since selection
- convert unrecoverable provider IllegalArgumentException failures into a false result instead of an app crash
- add regression coverage for oversized batches, stale rows, already-deleted items, and unrelated provider rejections

## Testing
- ANDROID_HOME=/Users/anil/Library/Android/sdk ./gradlew :core:media:testDebugUnitTest :core:media:lintDebug :core:media:ktlintCheck --rerun-tasks