### PR TITLE
Fix: Natural sort comparator contract violation

### DIFF
--- a/core/domain/src/test/java/dev/anilbeesetti/nextplayer/core/domain/GetSortedVideosUseCaseTest.kt
+++ b/core/domain/src/test/java/dev/anilbeesetti/nextplayer/core/domain/GetSortedVideosUseCaseTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class GetSortedVideosUseCaseTest {
@@ -119,6 +120,20 @@ class GetSortedVideosUseCaseTest {
         val sortedVideos = getSortedVideosUseCase().first()
 
         assertEquals(sortedVideos, testVideoItems.sortedByDescending { it.size })
+    }
+
+    @Test
+    fun testVideoComparator_whenTitlesContainMixedDigitScripts_doesNotCreateCycle() {
+        val comparator = Sort(Sort.By.TITLE, Sort.Order.ASCENDING).videoComparator()
+        val arabicNine = testVideoItems[0].copy(nameWithExtension = "٩.mp4")
+        val asciiZeroZero = testVideoItems[1].copy(nameWithExtension = "00.mp4")
+        val letterA = testVideoItems[2].copy(nameWithExtension = "a.mp4")
+
+        assertFalse(
+            comparator.compare(arabicNine, asciiZeroZero) < 0 &&
+                comparator.compare(asciiZeroZero, letterA) < 0 &&
+                comparator.compare(letterA, arabicNine) < 0,
+        )
     }
 }
 

--- a/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/Sort.kt
+++ b/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/Sort.kt
@@ -34,7 +34,7 @@ data class Sort(
 
             // If both chunks contain numeric characters, sort them numerically.
             val result: Int
-            if (thisChunk[0].isDigit() && thatChunk[0].isDigit()) {
+            if (thisChunk[0].isAsciiDigit() && thatChunk[0].isAsciiDigit()) {
                 // Simple chunk comparison by length.
                 val thisChunkLength = thisChunk.length
                 val lengthDiff = thisChunkLength - thatChunk.length
@@ -126,10 +126,10 @@ data class Sort(
         var c = string[current]
         chunk.append(c)
         current++
-        if (c.isDigit()) {
+        if (c.isAsciiDigit()) {
             while (current < length) {
                 c = string[current]
-                if (!c.isDigit()) {
+                if (!c.isAsciiDigit()) {
                     break
                 }
                 chunk.append(c)
@@ -138,7 +138,7 @@ data class Sort(
         } else {
             while (current < length) {
                 c = string[current]
-                if (c.isDigit()) {
+                if (c.isAsciiDigit()) {
                     break
                 }
                 chunk.append(c)
@@ -148,5 +148,8 @@ data class Sort(
         return chunk.toString()
     }
 }
+
+// The length-based numeric ordering is contract-safe only for the contiguous ASCII digit range.
+private fun Char.isAsciiDigit(): Boolean = this in '0'..'9'
 
 fun <T> Comparator<T>.reversedCompat(): Comparator<T> = kotlinReversed()


### PR DESCRIPTION
## Summary
- prevent comparator cycles when filenames mix Unicode digits, ASCII numbers, and text
- preserve natural numeric sorting for ASCII-numbered filenames
- add a regression test covering the production crash's non-transitive title ordering

## Root cause
The comparator used Char.isDigit for every Unicode digit script, then combined length-based numeric ordering with lexicographic text ordering. Inputs such as Arabic-Indic ٩, ASCII 00, and a could form a comparison cycle that TimSort rejects.

## Test plan
- ./gradlew :core:domain:testDebugUnitTest
- ./gradlew :core:model:ktlintCheck :core:domain:ktlintCheck