### PR TITLE
Fix: SMB connections in minified release builds

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -34,6 +34,11 @@
 -keep class com.hierynomus.ntlm.** { *; }
 -keep class com.hierynomus.security.** { *; }
 
+# mbassador creates the default handler invocation through Class.getConstructor().
+-keepclassmembers,allowobfuscation class net.engio.mbassy.dispatch.ReflectiveHandlerInvocation {
+    public <init>(net.engio.mbassy.subscription.SubscriptionContext);
+}
+
 # Optional runtime dependencies of the network libraries (smbj, mbassador,
 # okhttp/bouncycastle) that are not present on Android. Safe to ignore.
 -dontwarn javax.el.**


### PR DESCRIPTION
## Summary
- preserve mbassador’s reflectively invoked `ReflectiveHandlerInvocation(SubscriptionContext)` constructor
- keep the rule surgical while allowing class obfuscation
- fix SMB Test & Save failures in minified release builds

## Root cause
R8 removed the constructor because mbassador only reaches it through `Class.getConstructor(...)`. Existing SMBJ rules did not cover mbassador.

## Testing
- reproduced issue #1801 on an ephemeral emulator with the pre-fix minified APK
- verified the fixed APK reaches SMB networking; an intentional unreachable host returns `ECONNREFUSED`
- `./gradlew test ktlintCheck ':app:assembleRelease-with-debug-signing' --console=plain`
- installed and verified the arm64 release-with-debug-signing APK on a physical Android 16 device

Fixes #1801