### PR TITLE
Fix Android 7 storage permission crash

### DIFF
--- a/app/src/androidTest/java/dev/anilbeesetti/nextplayer/MainActivityPermissionTest.kt
+++ b/app/src/androidTest/java/dev/anilbeesetti/nextplayer/MainActivityPermissionTest.kt
@@ -1,0 +1,42 @@
+package dev.anilbeesetti.nextplayer
+
+import android.Manifest
+import android.app.ActivityManager
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.SystemClock
+import androidx.core.content.ContextCompat
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.anilbeesetti.nextplayer.core.common.storagePermission
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityPermissionTest {
+
+    @Test
+    fun api24RequestsReadStoragePermission() {
+        assertEquals(Manifest.permission.READ_EXTERNAL_STORAGE, storagePermission)
+    }
+
+    @Test
+    fun launchWithoutStoragePermissionKeepsMainActivityAlive() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        assertEquals(
+            PackageManager.PERMISSION_DENIED,
+            ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE),
+        )
+
+        context.startActivity(
+            Intent(context, MainActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+        SystemClock.sleep(1_000)
+
+        val activityManager = context.getSystemService(ActivityManager::class.java)
+        val topActivity = activityManager.appTasks.first().taskInfo?.topActivity
+        assertEquals(MainActivity::class.java.name, topActivity?.className)
+    }
+}

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/MainActivity.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/MainActivity.kt
@@ -36,7 +36,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import dev.anilbeesetti.nextplayer.core.common.service.system.SystemService
 import dev.anilbeesetti.nextplayer.core.media.network.proxy.NetworkStreamingProxy
 import dev.anilbeesetti.nextplayer.core.media.services.MediaOperationsService
-import dev.anilbeesetti.nextplayer.core.media.sync.MediaSynchronizer
 import dev.anilbeesetti.nextplayer.core.model.ThemeConfig
 import dev.anilbeesetti.nextplayer.core.ui.theme.NextPlayerTheme
 import dev.anilbeesetti.nextplayer.navigation.NextNavigationBar
@@ -53,9 +52,6 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-
-    @Inject
-    lateinit var synchronizer: MediaSynchronizer
 
     @Inject
     lateinit var mediaOperationsService: MediaOperationsService
@@ -78,8 +74,6 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         systemService.initialize(this@MainActivity)
         mediaOperationsService.initialize(this@MainActivity)
-        synchronizer.startSync()
-
         var uiState: MainActivityUiState by mutableStateOf(MainActivityUiState.Loading)
 
         lifecycleScope.launch {

--- a/core/common/src/main/java/dev/anilbeesetti/nextplayer/core/common/Utils.kt
+++ b/core/common/src/main/java/dev/anilbeesetti/nextplayer/core/common/Utils.kt
@@ -9,8 +9,7 @@ import kotlin.math.abs
 
 val storagePermission = when {
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU -> Manifest.permission.READ_MEDIA_VIDEO
-    Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> Manifest.permission.READ_EXTERNAL_STORAGE
-    else -> Manifest.permission.WRITE_EXTERNAL_STORAGE
+    else -> Manifest.permission.READ_EXTERNAL_STORAGE
 }
 
 /**

--- a/docs/superpowers/plans/2026-07-17-issue-1809-storage-permission-crash.md
+++ b/docs/superpowers/plans/2026-07-17-issue-1809-storage-permission-crash.md
@@ -1,0 +1,83 @@
+# Issue 1809 Storage Permission Crash Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent first launch from querying MediaStore before runtime storage permission is granted on Android 7.0.
+
+**Architecture:** Keep permission ownership in the media-picker feature. `MainActivity` no longer starts media synchronization unconditionally; `MediaPickerViewModel` starts synchronization and media collection together only when storage permission is already granted or after `OnPermissionAccepted`. Pre-Android 13 devices request the read permission that MediaStore enforces instead of relying on a write grant to imply read access.
+
+**Tech Stack:** Kotlin, Android runtime permissions, Hilt, coroutines/Flow, AndroidX instrumentation tests.
+
+## Global Constraints
+
+- Reproduce and verify on Android 7.0 (API 24) with app version 0.17.0 and storage permission denied.
+- Do not suppress `SecurityException` inside the MediaStore service.
+- Preserve the existing permission rationale and request UI.
+
+---
+
+### Task 1: Gate MediaStore Consumers Behind Permission
+
+**Files:**
+- Modify: `app/src/main/java/dev/anilbeesetti/nextplayer/MainActivity.kt`
+- Modify: `feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerViewModel.kt`
+- Test: `app/src/androidTest/java/dev/anilbeesetti/nextplayer/MainActivityPermissionTest.kt`
+- Modify: `core/common/src/main/java/dev/anilbeesetti/nextplayer/core/common/Utils.kt`
+
+**Interfaces:**
+- Consumes: `storagePermission`, `MediaSynchronizer.startSync()`, and `MediaPickerAction.OnPermissionAccepted`.
+- Produces: `MediaPickerViewModel.startMediaCollection()`, which starts synchronization and media collection only after permission is available.
+
+- [ ] **Step 1: Write the failing launch regression test**
+
+```kotlin
+@Test
+fun launchWithoutStoragePermissionKeepsMainActivityAlive() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    assertEquals(
+        PackageManager.PERMISSION_DENIED,
+        ContextCompat.checkSelfPermission(context, Manifest.permission.READ_EXTERNAL_STORAGE),
+    )
+
+    context.startActivity(
+        Intent(context, MainActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+    )
+    SystemClock.sleep(1_000)
+
+    val activityManager = context.getSystemService(ActivityManager::class.java)
+    val topActivity = activityManager.appTasks.first().taskInfo?.topActivity
+    assertEquals(MainActivity::class.java.name, topActivity?.className)
+}
+```
+
+- [ ] **Step 2: Verify the unfixed launch fails**
+
+Run: `ANDROID_HOME=/Users/anil/Library/Android/sdk ./gradlew :app:connectedDebugAndroidTest --tests dev.anilbeesetti.nextplayer.MainActivityPermissionTest --console=plain`
+
+Expected: FAIL because the uncaught MediaStore `SecurityException` terminates `MainActivity` and opens `CrashActivity`.
+
+- [ ] **Step 3: Gate synchronization and collection**
+
+```kotlin
+init {
+    if (ContextCompat.checkSelfPermission(context, storagePermission) == PackageManager.PERMISSION_GRANTED) {
+        startMediaCollection()
+    }
+    collectPreferences()
+}
+
+private fun startMediaCollection() {
+    mediaSynchronizer.startSync()
+    collectMedia()
+}
+```
+
+Remove the unconditional `synchronizer.startSync()` call and injection from `MainActivity`. Route `OnPermissionAccepted` through `startMediaCollection()`.
+
+For API levels below Android 13, set `storagePermission` to `Manifest.permission.READ_EXTERNAL_STORAGE`, matching the permission enforced by the MediaStore video query.
+
+- [ ] **Step 4: Verify the regression and emulator flow pass**
+
+Run: `ANDROID_HOME=/Users/anil/Library/Android/sdk ./gradlew :app:connectedDebugAndroidTest --tests dev.anilbeesetti.nextplayer.MainActivityPermissionTest --console=plain`
+
+Expected: PASS. On API 24, launching with permission denied displays the permission request without `SecurityException` or `CrashActivity`; accepting permission loads the media picker.

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerViewModel.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerViewModel.kt
@@ -1,7 +1,10 @@
 package dev.anilbeesetti.nextplayer.feature.videopicker.screens.mediapicker
 
+import android.content.Context
+import android.content.pm.PackageManager
 import android.net.Uri
 import androidx.compose.runtime.Stable
+import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -9,8 +12,10 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.anilbeesetti.nextplayer.core.common.extensions.prettyName
 import dev.anilbeesetti.nextplayer.core.common.service.system.SystemService
+import dev.anilbeesetti.nextplayer.core.common.storagePermission
 import dev.anilbeesetti.nextplayer.core.data.repository.MediaRepository
 import dev.anilbeesetti.nextplayer.core.data.repository.PreferencesRepository
 import dev.anilbeesetti.nextplayer.core.data.repository.VaultPinRepository
@@ -57,6 +62,7 @@ class MediaPickerViewModel @AssistedInject constructor(
     private val vaultRepository: VaultRepository,
     private val vaultPinRepository: VaultPinRepository,
     private val systemService: SystemService,
+    @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
     @AssistedFactory
@@ -81,7 +87,9 @@ class MediaPickerViewModel @AssistedInject constructor(
     private var transferJob: Job? = null
 
     init {
-        collectMedia()
+        if (ContextCompat.checkSelfPermission(context, storagePermission) == PackageManager.PERMISSION_GRANTED) {
+            startMediaCollection()
+        }
         collectPreferences()
     }
 
@@ -90,7 +98,7 @@ class MediaPickerViewModel @AssistedInject constructor(
             is MediaPickerAction.Refresh -> refresh()
             is MediaPickerAction.RenameVideo -> renameVideo(action.uri, action.to)
             is MediaPickerAction.UpdateMenu -> updateMenu(action.preferences)
-            is MediaPickerAction.OnPermissionAccepted -> collectMedia()
+            is MediaPickerAction.OnPermissionAccepted -> startMediaCollection()
             is MediaPickerAction.PlaySelectedItems -> playSelectedItems(action.selectionItems)
             is MediaPickerAction.DeleteSelectedItems -> deleteSelectedItems(action.selectionItems)
             is MediaPickerAction.ShareSelectedItems -> shareSelectedItems(action.selectionItems)
@@ -104,6 +112,11 @@ class MediaPickerViewModel @AssistedInject constructor(
             MediaPickerAction.ConfirmHidePendingItems -> confirmHidePendingItems()
             MediaPickerAction.DismissHideFlow -> uiStateInternal.update { it.copy(hideFlow = HideFlowState.Idle) }
         }
+    }
+
+    private fun startMediaCollection() {
+        mediaSynchronizer.startSync()
+        collectMedia()
     }
 
     private fun collectMedia() {


### PR DESCRIPTION
## Summary
- gate MediaStore synchronization and picker collection until storage permission is granted
- request `READ_EXTERNAL_STORAGE` on pre-Android 13 devices
- add API 24 launch regression coverage for denied and requested permissions

## Reproduction
- reproduced #1809 on a disposable Android 7.0/API 24 emulator
- launching without storage permission previously opened `CrashActivity` after a MediaStore `SecurityException`

## Testing
- `ANDROID_HOME=/Users/anil/Library/Android/sdk ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.anilbeesetti.nextplayer.MainActivityPermissionTest --console=plain`
- 2 tests passed on Android 7.0/API 24

Fixes #1809