### PR TITLE
Fix crash when Navigation 3 back stack becomes empty

### DIFF
--- a/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/MediaNavGraph.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/MediaNavGraph.kt
@@ -21,7 +21,7 @@ fun EntryProviderScope<NavKey>.mediaNavGraph(
     backStack: NavBackStack<NavKey>,
 ) {
     mediaPickerEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
         onPlayVideo = { uri -> context.startPlayback(listOf(uri)) },
         onPlayVideos = { uris -> context.startPlayback(uris) },
         onFolderClick = backStack::navigateToMediaPickerScreen,
@@ -31,13 +31,13 @@ fun EntryProviderScope<NavKey>.mediaNavGraph(
     )
 
     searchEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
         onPlayVideo = { uri -> context.startPlayback(listOf(uri)) },
         onFolderClick = backStack::navigateToMediaPickerScreen,
     )
 
     vaultEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
         // Vault files are served through FileProvider, so read access must be granted at
         // playback time for both PlayerActivity and the (separate) PlayerService component.
         onPlayVideo = { uri -> context.startPlayback(listOf(uri), grantReadPermission = true) },

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/NavBackStack.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/NavBackStack.kt
@@ -1,0 +1,13 @@
+package dev.anilbeesetti.nextplayer.navigation
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+
+/** Repairs an empty restored stack before it is passed to NavDisplay. */
+internal fun <T : NavKey> NavBackStack<T>.ensureRoot(root: T) {
+    if (isEmpty()) add(root)
+}
+
+/** Pops a nested destination while preserving the stack's required root entry. */
+internal fun <T : NavKey> NavBackStack<T>.removeLastIfNotRoot(): T? =
+    if (size > 1) removeLast() else null

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/NetworkNavGraph.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/NetworkNavGraph.kt
@@ -23,11 +23,11 @@ fun EntryProviderScope<NavKey>.networkNavGraph(
     )
 
     addConnectionEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
     )
 
     networkBrowseEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
         onPlayVideo = { uri -> context.startPlayback(listOf(uri)) },
         onNavigateToFolder = { id, path -> backStack.navigateToNetworkBrowse(id, path) },
     )

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/SettingsNavGraph.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/SettingsNavGraph.kt
@@ -34,7 +34,7 @@ fun EntryProviderScope<NavKey>.settingsNavGraph(
     backStack: NavBackStack<NavKey>,
 ) {
     settingsEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
         onItemClick = { setting ->
             when (setting) {
                 Setting.APPEARANCE -> backStack.navigateToAppearancePreferences()
@@ -50,42 +50,42 @@ fun EntryProviderScope<NavKey>.settingsNavGraph(
         },
     )
     appearancePreferencesEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
     )
     mediaLibraryPreferencesEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
         onFolderSettingClick = backStack::navigateToFolderPreferencesScreen,
         onThumbnailSettingClick = backStack::navigateToThumbnailPreferencesScreen,
     )
     thumbnailPreferencesEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
     )
     folderPreferencesEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
     )
     playerPreferencesEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
     )
     gesturePreferencesEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
     )
     decoderPreferencesEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
     )
     audioPreferencesEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
     )
     subtitlePreferencesEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
     )
     generalPreferencesEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
     )
     aboutPreferencesEntry(
         onLibrariesClick = backStack::navigateToLibraries,
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
     )
     librariesEntry(
-        onNavigateUp = { backStack.removeLastOrNull() },
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
     )
 }

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/TopLevelNavigation.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/TopLevelNavigation.kt
@@ -67,7 +67,11 @@ fun rememberTopLevelNavState(): TopLevelNavState {
     val destinations = TopLevelDestination.entries
     // Each tab keeps its own back stack; rememberNavBackStack persists it across config change and
     // process death.
-    val backStacks = destinations.associate { dest -> dest.route to rememberNavBackStack(dest.route) }
+    val backStacks = destinations.associate { dest ->
+        val backStack = rememberNavBackStack(dest.route)
+        backStack.ensureRoot(dest.route)
+        dest.route to backStack
+    }
     val selectedIndex = rememberSaveable { mutableIntStateOf(0) }
     return remember(backStacks, selectedIndex) {
         TopLevelNavState(destinations, backStacks, selectedIndex)

--- a/app/src/test/java/dev/anilbeesetti/nextplayer/navigation/NavBackStackTest.kt
+++ b/app/src/test/java/dev/anilbeesetti/nextplayer/navigation/NavBackStackTest.kt
@@ -1,0 +1,43 @@
+package dev.anilbeesetti.nextplayer.navigation
+
+import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NavBackStackTest {
+
+    @Test
+    fun removeLastIfNotRoot_removesTopEntryFromNestedStack() {
+        val backStack = NavBackStack<NavKey>(Root, Detail)
+
+        val removed = backStack.removeLastIfNotRoot()
+
+        assertEquals(Detail, removed)
+        assertEquals(listOf(Root), backStack)
+    }
+
+    @Test
+    fun removeLastIfNotRoot_keepsRootEntry() {
+        val backStack = NavBackStack<NavKey>(Root)
+
+        val removed = backStack.removeLastIfNotRoot()
+
+        assertNull(removed)
+        assertEquals(listOf(Root), backStack)
+    }
+
+    @Test
+    fun ensureRoot_restoresRootToEmptyStack() {
+        val backStack = NavBackStack<NavKey>()
+
+        backStack.ensureRoot(Root)
+
+        assertEquals(listOf(Root), backStack)
+    }
+
+    private data object Root : NavKey
+
+    private data object Detail : NavKey
+}


### PR DESCRIPTION
## Summary
- preserve each top-level Navigation 3 root when feature screens navigate up
- repair previously restored empty tab stacks before composing NavDisplay
- add regression tests for guarded popping and empty-stack restoration

## Testing
- ./gradlew :app:ktlintCheck :app:testDebugUnitTest :app:assembleDebug --console=plain