### PR TITLE
Fix completed video progress indicator

### DIFF
--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -18,4 +18,5 @@ tasks.withType<JavaCompile> {
 
 dependencies {
     implementation(libs.kotlinx.serialization.json)
+    testImplementation(libs.junit4)
 }

--- a/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/Video.kt
+++ b/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/Video.kt
@@ -26,7 +26,11 @@ data class Video(
 
     val displayName: String = nameWithExtension.substringBeforeLast(".")
     val playedPercentage: Float? = playbackPosition?.let { playbackPosition ->
-        (playbackPosition.toFloat() / duration.toFloat()).takeIf { playbackPosition >= 0 && duration > 0 }
+        when {
+            duration <= 0 -> null
+            playbackPosition < 0 -> 1f
+            else -> playbackPosition.toFloat() / duration.toFloat()
+        }
     }
 
     companion object {

--- a/core/model/src/test/java/dev/anilbeesetti/nextplayer/core/model/VideoTest.kt
+++ b/core/model/src/test/java/dev/anilbeesetti/nextplayer/core/model/VideoTest.kt
@@ -1,0 +1,17 @@
+package dev.anilbeesetti.nextplayer.core.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VideoTest {
+
+    @Test
+    fun finishedVideoHasFullPlayedPercentage() {
+        val video = Video.sample.copy(
+            duration = 1_000L,
+            playbackPosition = -1L,
+        )
+
+        assertEquals(1f, video.playedPercentage)
+    }
+}

--- a/docs/superpowers/plans/2026-07-19-finished-video-progress.md
+++ b/docs/superpowers/plans/2026-07-19-finished-video-progress.md
@@ -1,0 +1,115 @@
+# Finished Video Progress Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore a full progress bar on `VideoItem` after a video has been watched to the end.
+
+**Architecture:** Keep the player's finished sentinel and the Compose rendering condition unchanged. Normalize a negative persisted playback position to `1f` in the `Video` model, where persisted playback state is already translated into UI-ready progress.
+
+**Tech Stack:** Kotlin/JVM, JUnit 4, Gradle
+
+## Global Constraints
+
+- `null` playback position means never played and must continue to produce `null` progress.
+- A non-negative position with a positive duration must continue to produce the position-to-duration ratio.
+- A negative position with a positive duration must produce `1f` progress.
+- A non-positive duration must continue to produce `null` progress.
+- Do not change player persistence or Compose rendering behavior.
+
+---
+
+### Task 1: Restore completed-video progress translation
+
+**Files:**
+- Modify: `core/model/build.gradle.kts`
+- Create: `core/model/src/test/java/dev/anilbeesetti/nextplayer/core/model/VideoTest.kt`
+- Modify: `core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/Video.kt:28`
+
+**Interfaces:**
+- Consumes: `Video.playbackPosition: Long?`, where a negative value is the persisted finished marker.
+- Produces: `Video.playedPercentage: Float?`, with `1f` representing completed playback and `null` representing no displayable progress.
+
+- [x] **Step 1: Add the model test dependency and failing regression test**
+
+Add JUnit 4 to `core/model/build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation(libs.kotlinx.serialization.json)
+    testImplementation(libs.junit4)
+}
+```
+
+Create `core/model/src/test/java/dev/anilbeesetti/nextplayer/core/model/VideoTest.kt`:
+
+```kotlin
+package dev.anilbeesetti.nextplayer.core.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class VideoTest {
+
+    @Test
+    fun finishedVideoHasFullPlayedPercentage() {
+        val video = Video.sample.copy(
+            duration = 1_000L,
+            playbackPosition = -1L,
+        )
+
+        assertEquals(1f, video.playedPercentage)
+    }
+}
+```
+
+- [x] **Step 2: Run the focused test and verify the regression**
+
+Run:
+
+```bash
+./gradlew :core:model:test --tests dev.anilbeesetti.nextplayer.core.model.VideoTest.finishedVideoHasFullPlayedPercentage
+```
+
+Expected: FAIL because `video.playedPercentage` is `null` instead of `1f`.
+
+- [x] **Step 3: Implement the minimal model fix**
+
+Replace the `playedPercentage` calculation in `core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/Video.kt` with:
+
+```kotlin
+val playedPercentage: Float? = playbackPosition?.let { playbackPosition ->
+    when {
+        duration <= 0 -> null
+        playbackPosition < 0 -> 1f
+        else -> playbackPosition.toFloat() / duration.toFloat()
+    }
+}
+```
+
+- [x] **Step 4: Run the focused model suite and compile the affected UI module**
+
+Run:
+
+```bash
+./gradlew :core:model:test :feature:videopicker:compileDebugKotlin
+```
+
+Expected: BUILD SUCCESSFUL, including a passing `VideoTest`.
+
+- [x] **Step 5: Run repository formatting and diff checks**
+
+Run:
+
+```bash
+./gradlew ktlintCheck
+git diff --check
+```
+
+Expected: both commands succeed with no formatting or whitespace errors.
+
+- [x] **Step 6: Commit the regression test and fix**
+
+```bash
+git add core/model/build.gradle.kts core/model/src/test/java/dev/anilbeesetti/nextplayer/core/model/VideoTest.kt core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/Video.kt docs/superpowers/plans/2026-07-19-finished-video-progress.md
+git commit -m "fix: show progress for completed videos"
+```

--- a/docs/superpowers/specs/2026-07-19-finished-video-progress-design.md
+++ b/docs/superpowers/specs/2026-07-19-finished-video-progress-design.md
@@ -1,0 +1,29 @@
+# Finished Video Progress Design
+
+## Context
+
+Issue #1817 reports that the media picker no longer shows a progress bar after a video has been watched to the end. Partial playback progress is still displayed.
+
+The player persists `C.TIME_UNSET`, a negative value, when playback finishes. This is intentional: the absence of a resumable position makes a completed video start from the beginning when it is played again. In v0.16.3, `Video.playedPercentage` translated a negative persisted position to `1f`, so `VideoItem` rendered a full progress bar. The v0.17 media-state refactor made playback positions nullable and accidentally translated the finished sentinel to `null`; `VideoItem` interprets `null` as no progress to display.
+
+## Design
+
+Keep the persistence and Compose layers unchanged. Restore the finished-state translation in `Video.playedPercentage`:
+
+- `null` playback position means the video has never been played and produces `null` progress.
+- A non-negative playback position with a positive duration produces the existing position-to-duration ratio.
+- A negative playback position with a positive duration represents completed playback and produces `1f` progress.
+- A non-positive duration cannot produce meaningful progress and continues to produce `null`.
+
+Because `VideoItem` already renders the progress bar whenever `playedPercentage` is non-null, a completed video will render a full-width bar without exposing the player sentinel to the UI.
+
+## Testing
+
+Add a JVM unit test in `core:model` that creates a video with a negative finished position and a valid duration, then asserts that `playedPercentage` is `1f`. Run it before the production change to confirm that it fails by returning `null`, then rerun it after the model change.
+
+The focused module test suite and relevant compilation checks must pass. Existing behavior for never-played and partially played videos remains unchanged by the implementation.
+
+## Alternatives Considered
+
+- Persist the media duration at completion. Rejected because a completed video could be treated as resumable at its end instead of restarting from the beginning.
+- Handle negative positions in `VideoItem`. Rejected because it would leak the player persistence sentinel into the Compose layer and duplicate model interpretation in UI code.


### PR DESCRIPTION
## Summary

- restore full progress for videos watched to completion
- keep completed videos restarting from the beginning
- add a JVM regression test for the finished playback sentinel

## Verification

- confirmed the regression test fails before the fix with expected 1.0 but was null
- ./gradlew :core:model:test :feature:videopicker:compileDebugKotlin ktlintCheck --rerun-tasks
- git diff --check

Fixes #1817