### PR TITLE
Fix single selected video autoplay

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -140,6 +140,7 @@ dependencies {
     implementation(libs.github.anilbeesetti.nextlib.mediainfo)
 
     testImplementation(libs.junit4)
+    testImplementation(libs.robolectric)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.test.ext)
     androidTestImplementation(libs.androidx.test.espresso.core)

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/MediaNavGraph.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/MediaNavGraph.kt
@@ -22,7 +22,7 @@ fun EntryProviderScope<NavKey>.mediaNavGraph(
 ) {
     mediaPickerEntry(
         onNavigateUp = { backStack.removeLastOrNull() },
-        onPlayVideo = { uri -> context.startPlayback(listOf(uri)) },
+        onPlayVideo = { uri -> context.startPlayback(uri) },
         onPlayVideos = { uris -> context.startPlayback(uris) },
         onFolderClick = backStack::navigateToMediaPickerScreen,
         onSettingsClick = backStack::navigateToSettings,
@@ -32,7 +32,7 @@ fun EntryProviderScope<NavKey>.mediaNavGraph(
 
     searchEntry(
         onNavigateUp = { backStack.removeLastOrNull() },
-        onPlayVideo = { uri -> context.startPlayback(listOf(uri)) },
+        onPlayVideo = { uri -> context.startPlayback(uri) },
         onFolderClick = backStack::navigateToMediaPickerScreen,
     )
 
@@ -40,19 +40,30 @@ fun EntryProviderScope<NavKey>.mediaNavGraph(
         onNavigateUp = { backStack.removeLastOrNull() },
         // Vault files are served through FileProvider, so read access must be granted at
         // playback time for both PlayerActivity and the (separate) PlayerService component.
-        onPlayVideo = { uri -> context.startPlayback(listOf(uri), grantReadPermission = true) },
+        onPlayVideo = { uri -> context.startPlayback(uri, grantReadPermission = true) },
         onPlayVideos = { uris -> context.startPlayback(uris, grantReadPermission = true) },
     )
 }
 
+internal fun Context.startPlayback(uri: Uri, grantReadPermission: Boolean = false) {
+    startPlayback(uri = uri, playlist = null, grantReadPermission = grantReadPermission)
+}
+
 internal fun Context.startPlayback(uris: List<Uri>, grantReadPermission: Boolean = false) {
+    val uri = uris.firstOrNull() ?: return
+    startPlayback(uri = uri, playlist = uris, grantReadPermission = grantReadPermission)
+}
+
+private fun Context.startPlayback(uri: Uri, playlist: List<Uri>?, grantReadPermission: Boolean) {
     if (grantReadPermission) {
-        uris.forEach { grantUriPermission(packageName, it, Intent.FLAG_GRANT_READ_URI_PERMISSION) }
+        (playlist ?: listOf(uri)).forEach {
+            grantUriPermission(packageName, it, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
     }
     val intent = Intent(this, PlayerActivity::class.java).apply {
         action = Intent.ACTION_VIEW
-        data = uris.first()
-        if (uris.size > 1) putParcelableArrayListExtra(PlayerApi.API_PLAYLIST, ArrayList(uris))
+        data = uri
+        playlist?.let { putParcelableArrayListExtra(PlayerApi.API_PLAYLIST, ArrayList(it)) }
         if (grantReadPermission) addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
     }
     startActivity(intent)

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/NetworkNavGraph.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/NetworkNavGraph.kt
@@ -28,7 +28,7 @@ fun EntryProviderScope<NavKey>.networkNavGraph(
 
     networkBrowseEntry(
         onNavigateUp = { backStack.removeLastOrNull() },
-        onPlayVideo = { uri -> context.startPlayback(listOf(uri)) },
+        onPlayVideo = { uri -> context.startPlayback(uri) },
         onNavigateToFolder = { id, path -> backStack.navigateToNetworkBrowse(id, path) },
     )
 }

--- a/app/src/test/java/dev/anilbeesetti/nextplayer/navigation/MediaNavGraphTest.kt
+++ b/app/src/test/java/dev/anilbeesetti/nextplayer/navigation/MediaNavGraphTest.kt
@@ -1,0 +1,53 @@
+package dev.anilbeesetti.nextplayer.navigation
+
+import android.app.Activity
+import android.net.Uri
+import androidx.core.content.IntentCompat
+import androidx.core.net.toUri
+import dev.anilbeesetti.nextplayer.feature.player.utils.PlayerApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+class MediaNavGraphTest {
+
+    @Test
+    fun `single item explicit playlist is included in playback intent`() {
+        val context = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val uri = "content://media/external/video/media/1821".toUri()
+
+        context.startPlayback(listOf(uri))
+
+        val intent = shadowOf(context).nextStartedActivity
+        assertEquals(
+            arrayListOf(uri),
+            IntentCompat.getParcelableArrayListExtra(intent, PlayerApi.API_PLAYLIST, Uri::class.java),
+        )
+    }
+
+    @Test
+    fun `single video playback does not include explicit playlist`() {
+        val context = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val uri = "content://media/external/video/media/1821".toUri()
+
+        context.startPlayback(uri)
+
+        val intent = shadowOf(context).nextStartedActivity
+        assertFalse(intent.hasExtra(PlayerApi.API_PLAYLIST))
+    }
+
+    @Test
+    fun `empty explicit playlist does not start playback`() {
+        val context = Robolectric.buildActivity(Activity::class.java).setup().get()
+
+        context.startPlayback(emptyList())
+
+        assertNull(shadowOf(context).nextStartedActivity)
+    }
+}

--- a/docs/superpowers/plans/2026-07-19-issue-1821-single-selection-autoplay.md
+++ b/docs/superpowers/plans/2026-07-19-issue-1821-single-selection-autoplay.md
@@ -1,0 +1,144 @@
+# Issue 1821 Single-Selection Autoplay Regression Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the pre-0.17 behavior where playing one explicitly selected video stops after that video, while a normal tap still uses the autoplay-generated folder playlist.
+
+**Architecture:** Keep the existing intent contract in which `PlayerApi.API_PLAYLIST` marks an explicit playlist. Separate the direct-video and explicit-playlist launch paths with overloads so a one-item explicit playlist retains its semantic meaning instead of being inferred from list size.
+
+**Tech Stack:** Kotlin, Android intents, JUnit 4, Robolectric, Gradle version catalog
+
+## Global Constraints
+
+- Preserve normal single-video autoplay behavior.
+- Preserve explicit multi-selection and vault URI-permission behavior.
+- Add a regression test that fails on commit `700f5986` and passes after the fix.
+- Do not refactor unrelated playback or navigation code.
+
+---
+
+### Task 1: Prove and fix explicit one-item playlist intent creation
+
+**Files:**
+- Modify: `gradle/libs.versions.toml`
+- Modify: `app/build.gradle.kts`
+- Create: `app/src/test/java/dev/anilbeesetti/nextplayer/navigation/MediaNavGraphTest.kt`
+- Modify: `app/src/main/java/dev/anilbeesetti/nextplayer/navigation/MediaNavGraph.kt`
+- Modify: `app/src/main/java/dev/anilbeesetti/nextplayer/navigation/NetworkNavGraph.kt`
+
+**Interfaces:**
+- Consumes: `Context.startPlayback(uris: List<Uri>, grantReadPermission: Boolean)` and `PlayerApi.API_PLAYLIST`
+- Produces: distinct `Context.startPlayback(uri: Uri, ...)` and `Context.startPlayback(uris: List<Uri>, ...)` launch semantics
+
+- [x] **Step 1: Add Robolectric JVM-test support**
+
+Add the cached Robolectric `4.16.1` dependency to the version catalog and the app module's `testImplementation` dependencies.
+
+- [x] **Step 2: Write the failing regression test**
+
+```kotlin
+@RunWith(RobolectricTestRunner::class)
+class MediaNavGraphTest {
+    @Test
+    fun `single item explicit playlist is included in playback intent`() {
+        val context = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val uri = "content://media/external/video/media/1821".toUri()
+
+        context.startPlayback(listOf(uri))
+
+        val intent = shadowOf(context).nextStartedActivity
+        assertEquals(
+            arrayListOf(uri),
+            IntentCompat.getParcelableArrayListExtra(intent, PlayerApi.API_PLAYLIST, Uri::class.java),
+        )
+    }
+}
+```
+
+- [x] **Step 3: Run the focused test to verify the regression exists**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*MediaNavGraphTest*'`
+
+Expected: FAIL because the current `uris.size > 1` guard omits `PlayerApi.API_PLAYLIST` for the single selected URI.
+
+- [x] **Step 4: Separate direct-video and explicit-playlist launches**
+
+Add a `Uri` overload that launches without `API_PLAYLIST`, update all `onPlayVideo` callbacks to use it, and make the existing `List<Uri>` overload always write `API_PLAYLIST`. Keep read-permission handling identical in both overloads.
+
+- [x] **Step 5: Run the focused test to verify the fix**
+
+Run: `./gradlew :app:testDebugUnitTest --tests '*MediaNavGraphTest*'`
+
+Expected: PASS.
+
+- [x] **Step 6: Run relevant verification**
+
+Run: `./gradlew :app:testDebugUnitTest :app:compileDebugKotlin`
+
+Expected: BUILD SUCCESSFUL with no test failures or compilation errors.
+
+- [x] **Step 7: Review the final diff**
+
+Run: `git diff --check && git diff -- app/build.gradle.kts gradle/libs.versions.toml app/src/main app/src/test docs/superpowers/plans`
+
+Expected: only the focused regression test, test dependency, playback-launch fix, and this plan are changed.
+
+### Task 2: Preserve playback intent through vault events
+
+**Files:**
+- Modify: `feature/videopicker/build.gradle.kts`
+- Create: `feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultPlaybackEventTest.kt`
+- Modify: `feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt`
+- Modify: `feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt`
+
+**Interfaces:**
+- Consumes: `VaultAction.PlayVideo`, `VaultAction.PlaySelected`, `VaultRoute` playback callbacks
+- Produces: distinct `VaultEvent.PlayVideo(Uri)` and `VaultEvent.PlayVideos(List<Uri>)` events
+
+- [x] **Step 1: Write the failing vault event regression test**
+
+Drive `VaultAction.PlayVideo` through a real `VaultViewModel` with lightweight repository fakes and verify that it emits `VaultEvent.PlayVideo` rather than `PlayVideos`.
+
+- [x] **Step 2: Run the focused test to verify the distinction is missing**
+
+Run: `./gradlew :feature:videopicker:testDebugUnitTest --tests '*VaultPlaybackEventTest*'`
+
+Expected: compilation fails because `VaultEvent.PlayVideo` does not exist.
+
+- [x] **Step 3: Separate direct and selected vault events**
+
+Emit `PlayVideo` for an ordinary vault item tap, retain `PlayVideos` for explicit selection, and dispatch each event directly to its matching route callback without checking list size.
+
+- [x] **Step 4: Run the focused test to verify the fix**
+
+Run: `./gradlew :feature:videopicker:testDebugUnitTest --tests '*VaultPlaybackEventTest*'`
+
+Expected: PASS.
+
+### Task 3: Harden and verify the complete playback boundary
+
+**Files:**
+- Modify: `app/src/test/java/dev/anilbeesetti/nextplayer/navigation/MediaNavGraphTest.kt`
+- Modify: `app/src/main/java/dev/anilbeesetti/nextplayer/navigation/MediaNavGraph.kt`
+
+- [x] **Step 1: Add an empty explicit-playlist regression test**
+
+Verify that a stale or empty resolved selection does not launch playback or throw.
+
+- [x] **Step 2: Run the test and observe the existing crash**
+
+Expected: FAIL with `NoSuchElementException` from `uris.first()`.
+
+- [x] **Step 3: Ignore empty explicit playlists at the playback boundary**
+
+Use `firstOrNull() ?: return` before constructing the playback intent.
+
+- [x] **Step 4: Run combined final verification**
+
+Run app and videopicker unit tests, compile both changed modules, run their formatting checks, inspect XML results for zero failures, and run `git diff --check`.
+
+## Self-Review
+
+- Spec coverage: root cause, failing tests, media-picker and vault fixes, and broader verification are all covered.
+- Placeholder scan: no TODO/TBD or deferred implementation steps.
+- Type consistency: both overloads consume Android `Uri`; only the list overload produces `API_PLAYLIST`.

--- a/feature/videopicker/build.gradle.kts
+++ b/feature/videopicker/build.gradle.kts
@@ -66,6 +66,8 @@ dependencies {
     implementation(libs.androidx.hilt.navigation.compose)
 
     testImplementation(libs.junit4)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.test.ext)
     androidTestImplementation(libs.androidx.test.espresso.core)

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt
@@ -106,9 +106,8 @@ fun VaultRoute(
 
     ObserveAsEvents(flow = viewModel.events) { event ->
         when (event) {
-            is VaultEvent.PlayVideos -> {
-                if (event.uris.size == 1) onPlayVideo(event.uris.first()) else onPlayVideos(event.uris)
-            }
+            is VaultEvent.PlayVideo -> onPlayVideo(event.uri)
+            is VaultEvent.PlayVideos -> onPlayVideos(event.uris)
 
             is VaultEvent.VideosRelocated -> {
                 val message = context.resources.getQuantityString(

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt
@@ -131,7 +131,7 @@ class VaultViewModel @Inject constructor(
 
     private fun playVideo(video: Video) {
         viewModelScope.launch {
-            eventsInternal.send(VaultEvent.PlayVideos(listOf(video.uriString.toUri())))
+            eventsInternal.send(VaultEvent.PlayVideo(video.uriString.toUri()))
         }
     }
 
@@ -213,6 +213,7 @@ sealed interface VaultAction {
 }
 
 sealed interface VaultEvent {
+    data class PlayVideo(val uri: Uri) : VaultEvent
     data class PlayVideos(val uris: List<Uri>) : VaultEvent
     data class VideosRelocated(val count: Int) : VaultEvent
 }

--- a/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultPlaybackEventTest.kt
+++ b/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultPlaybackEventTest.kt
@@ -1,0 +1,97 @@
+package dev.anilbeesetti.nextplayer.feature.videopicker.screens.vault
+
+import androidx.core.net.toUri
+import dev.anilbeesetti.nextplayer.core.data.repository.PreferencesRepository
+import dev.anilbeesetti.nextplayer.core.data.repository.UnhideResult
+import dev.anilbeesetti.nextplayer.core.data.repository.VaultPinRepository
+import dev.anilbeesetti.nextplayer.core.data.repository.VaultRepository
+import dev.anilbeesetti.nextplayer.core.domain.GetHiddenVideosUseCase
+import dev.anilbeesetti.nextplayer.core.model.ApplicationPreferences
+import dev.anilbeesetti.nextplayer.core.model.MediaInfo
+import dev.anilbeesetti.nextplayer.core.model.PlayerPreferences
+import dev.anilbeesetti.nextplayer.core.model.Video
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class VaultPlaybackEventTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `direct video action emits direct playback event`() = runTest(testDispatcher.scheduler) {
+        val uri = "content://dev.anilbeesetti.nextplayer.fileprovider/vault/1821".toUri()
+        val viewModel = VaultViewModel(
+            vaultRepository = FakeVaultRepository,
+            vaultPinRepository = FakeVaultPinRepository,
+            getHiddenVideosUseCase = GetHiddenVideosUseCase(FakeVaultRepository, testDispatcher),
+            preferencesRepository = FakePreferencesRepository(),
+        )
+        val event = async(start = CoroutineStart.UNDISPATCHED) { viewModel.events.first() }
+
+        viewModel.onAction(VaultAction.PlayVideo(Video.sample.copy(uriString = uri.toString())))
+        advanceUntilIdle()
+
+        assertEquals(VaultEvent.PlayVideo(uri), event.await())
+    }
+
+    private data object FakeVaultRepository : VaultRepository {
+        override fun observeHiddenVideos(): Flow<List<Video>> = emptyFlow()
+        override suspend fun hideVideos(videos: List<Video>) = Unit
+        override suspend fun unhideVideos(videos: List<Video>) = UnhideResult()
+        override suspend fun deleteHiddenVideos(videos: List<Video>) = Unit
+        override suspend fun getHiddenVideoInfo(id: Long): MediaInfo? = null
+    }
+
+    private data object FakeVaultPinRepository : VaultPinRepository {
+        override suspend fun hasPinSet(): Boolean = false
+        override suspend fun setPin(pin: String) = Unit
+        override suspend fun verifyPin(pin: String): Boolean = false
+        override suspend fun hasShownHideConfirmation(): Boolean = false
+        override suspend fun setHideConfirmationShown() = Unit
+    }
+
+    private class FakePreferencesRepository : PreferencesRepository {
+        override val applicationPreferences: StateFlow<ApplicationPreferences> = MutableStateFlow(ApplicationPreferences())
+        override val playerPreferences: StateFlow<PlayerPreferences> = MutableStateFlow(PlayerPreferences())
+
+        override suspend fun updateApplicationPreferences(
+            transform: suspend (ApplicationPreferences) -> ApplicationPreferences,
+        ) = Unit
+
+        override suspend fun updatePlayerPreferences(
+            transform: suspend (PlayerPreferences) -> PlayerPreferences,
+        ) = Unit
+
+        override suspend fun resetPreferences() = Unit
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ ksp = "2.3.10"
 ktlint = "12.3.0"
 reorderable = "3.1.0"
 room = "2.8.4"
+robolectric = "4.16.1"
 nextlib = "1.10.1-0.13.0"
 universalChardet = "2.5.0"
 smbj = "0.14.0"
@@ -98,6 +99,7 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlin-metadata-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-metadata-jvm", version.ref = "kotlin" }
 reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 smbj = { group = "com.hierynomus", name = "smbj", version.ref = "smbj" }
 commons-net = { group = "commons-net", name = "commons-net", version.ref = "commonsNet" }
 sardine-android = { group = "com.github.thegrizzlylabs", name = "sardine-android", version.ref = "sardineAndroid" }


### PR DESCRIPTION
## Summary
- preserve the distinction between direct playback and explicit playlists
- keep single selected media and vault videos from falling through to autoplay
- ignore empty resolved playlists safely

## Regression
Issue #1821 was introduced when playback intent semantics were inferred from playlist size. A one-item explicit selection no longer included PlayerApi.API_PLAYLIST, so the player rebuilt the folder autoplay playlist.

## Tests
- :app:testDebugUnitTest
- :feature:videopicker:testDebugUnitTest
- :app:compileDebugKotlin
- :feature:videopicker:compileDebugKotlin
- :app:ktlintCheck
- :feature:videopicker:ktlintCheck

Fixes #1821