### PR TITLE
Fix MediaStore write request URI limit crash

### DIFF
--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsService.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsService.kt
@@ -250,7 +250,14 @@ class LocalMediaOperationsService @Inject constructor(
     }
 
     @RequiresApi(Build.VERSION_CODES.R)
-    private suspend fun requestWriteAccessR(uris: List<Uri>): Boolean = suspendCancellableCoroutine { continuation ->
+    private suspend fun requestWriteAccessR(uris: List<Uri>): Boolean = runMediaWriteRequests(
+        uris = uris,
+        itemExists = ::mediaExists,
+        request = ::requestWriteR,
+    )
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private suspend fun requestWriteR(uris: List<Uri>): Boolean = suspendCancellableCoroutine { continuation ->
         launchWriteRequest(
             uris = uris,
             onResultOk = { continuation.resume(true) },

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaRequestRunner.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaRequestRunner.kt
@@ -2,6 +2,16 @@ package dev.anilbeesetti.nextplayer.core.media.services
 
 internal const val MAX_MEDIA_REQUEST_URIS = 2_000
 
+internal suspend fun <T> runMediaWriteRequests(
+    uris: List<T>,
+    itemExists: suspend (T) -> Boolean,
+    request: suspend (List<T>) -> Boolean,
+): Boolean = runMediaRequests(
+    items = uris,
+    itemExists = itemExists,
+    request = request,
+)
+
 internal suspend fun <T> runMediaRequests(
     items: List<T>,
     maxBatchSize: Int = MAX_MEDIA_REQUEST_URIS,

--- a/core/media/src/test/java/dev/anilbeesetti/nextplayer/core/media/services/MediaRequestRunnerTest.kt
+++ b/core/media/src/test/java/dev/anilbeesetti/nextplayer/core/media/services/MediaRequestRunnerTest.kt
@@ -9,6 +9,24 @@ import org.junit.Test
 class MediaRequestRunnerTest {
 
     @Test
+    fun `splits write access requests at the platform uri limit`() = runBlocking {
+        val requestedBatchSizes = mutableListOf<Int>()
+
+        val result = runMediaWriteRequests(
+            uris = (1..2_001).toList(),
+            itemExists = { true },
+            request = { batch ->
+                require(batch.size <= MAX_MEDIA_REQUEST_URIS)
+                requestedBatchSizes += batch.size
+                true
+            },
+        )
+
+        assertTrue(result)
+        assertEquals(listOf(2_000, 1), requestedBatchSizes)
+    }
+
+    @Test
     fun `splits requests at the platform uri limit`() = runBlocking {
         val requestedBatchSizes = mutableListOf<Int>()
 

--- a/docs/superpowers/plans/2026-07-20-mediastore-write-request-limit.md
+++ b/docs/superpowers/plans/2026-07-20-mediastore-write-request-limit.md
@@ -1,0 +1,141 @@
+# MediaStore Write Request Limit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent moves of more than 2,000 MediaStore items from crashing while requesting write access.
+
+**Architecture:** Add a small write-access entry point around the existing `runMediaRequests()` batching engine, then route `LocalMediaOperationsService.requestWriteAccessR()` through it. The service launches one system consent request at a time and performs the existing file moves only after every batch succeeds.
+
+**Tech Stack:** Kotlin, Android MediaStore, coroutines, JUnit 4, Gradle.
+
+## Global Constraints
+
+- Each `MediaStore.createWriteRequest()` receives at most 2,000 distinct URIs.
+- Requests are sequential because the service owns one activity-result callback pair.
+- Cancelling or rejecting any batch stops later requests and preserves the existing all-failed move result.
+- Stale URI recovery must match the existing delete-request behavior.
+- Do not change Storage Access Framework transfers, rename requests, or move result types.
+
+---
+
+### Task 1: Batch MediaStore Write-Access Requests
+
+**Files:**
+- Modify: `core/media/src/test/java/dev/anilbeesetti/nextplayer/core/media/services/MediaRequestRunnerTest.kt:9-90`
+- Modify: `core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaRequestRunner.kt:3-17`
+- Modify: `core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsService.kt:252-259`
+
+**Interfaces:**
+- Consumes: `runMediaRequests(items, maxBatchSize, itemExists, request): Boolean`, `mediaExists(uri): Boolean`, and `launchWriteRequest(uris, onResultCanceled, onResultOk)`.
+- Produces: `internal suspend fun <T> runMediaWriteRequests(uris: List<T>, itemExists: suspend (T) -> Boolean, request: suspend (List<T>) -> Boolean): Boolean` and a private single-batch `requestWriteR(uris: List<Uri>): Boolean`.
+
+- [x] **Step 1: Write the failing write-access regression test**
+
+Add this test to `MediaRequestRunnerTest`:
+
+```kotlin
+@Test
+fun `splits write access requests at the platform uri limit`() = runBlocking {
+    val requestedBatchSizes = mutableListOf<Int>()
+
+    val result = runMediaWriteRequests(
+        uris = (1..2_001).toList(),
+        itemExists = { true },
+        request = { batch ->
+            require(batch.size <= MAX_MEDIA_REQUEST_URIS)
+            requestedBatchSizes += batch.size
+            true
+        },
+    )
+
+    assertTrue(result)
+    assertEquals(listOf(2_000, 1), requestedBatchSizes)
+}
+```
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+./gradlew :core:media:testDebugUnitTest --tests 'dev.anilbeesetti.nextplayer.core.media.services.MediaRequestRunnerTest.splits write access requests at the platform uri limit'
+```
+
+Expected: Kotlin test compilation fails with `Unresolved reference 'runMediaWriteRequests'`, proving the regression test requires the missing write-request batching entry point.
+
+- [x] **Step 3: Add the minimal write-request batching entry point**
+
+Add to `MediaRequestRunner.kt`:
+
+```kotlin
+internal suspend fun <T> runMediaWriteRequests(
+    uris: List<T>,
+    itemExists: suspend (T) -> Boolean,
+    request: suspend (List<T>) -> Boolean,
+): Boolean = runMediaRequests(
+    items = uris,
+    itemExists = itemExists,
+    request = request,
+)
+```
+
+- [x] **Step 4: Route service write access through sequential batches**
+
+Replace `requestWriteAccessR()` with:
+
+```kotlin
+@RequiresApi(Build.VERSION_CODES.R)
+private suspend fun requestWriteAccessR(uris: List<Uri>): Boolean = runMediaWriteRequests(
+    uris = uris,
+    itemExists = ::mediaExists,
+    request = ::requestWriteR,
+)
+
+@RequiresApi(Build.VERSION_CODES.R)
+private suspend fun requestWriteR(uris: List<Uri>): Boolean = suspendCancellableCoroutine { continuation ->
+    launchWriteRequest(
+        uris = uris,
+        onResultOk = { continuation.resume(true) },
+        onResultCanceled = { continuation.resume(false) },
+    )
+}
+```
+
+- [x] **Step 5: Run the focused regression test and verify GREEN**
+
+Run:
+
+```bash
+./gradlew :core:media:testDebugUnitTest --tests 'dev.anilbeesetti.nextplayer.core.media.services.MediaRequestRunnerTest.splits write access requests at the platform uri limit'
+```
+
+Expected: PASS; recorded batch sizes are exactly `2,000` and `1`.
+
+- [x] **Step 6: Run core-media tests**
+
+Run:
+
+```bash
+./gradlew :core:media:testDebugUnitTest
+```
+
+Expected: PASS with zero failed tests.
+
+- [x] **Step 7: Compile the app integration**
+
+Run:
+
+```bash
+ANDROID_HOME=/Users/anil/Library/Android/sdk ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk ./gradlew -q :app:compileDebugKotlin
+```
+
+Expected: exit code 0 with no Kotlin compilation errors.
+
+- [x] **Step 8: Review and commit the fix**
+
+Review `git diff --check` and the scoped diff, then run the focused test once more as fresh completion evidence.
+
+```bash
+git add core/media/src/test/java/dev/anilbeesetti/nextplayer/core/media/services/MediaRequestRunnerTest.kt core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaRequestRunner.kt core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsService.kt docs/superpowers/plans/2026-07-20-mediastore-write-request-limit.md
+git commit -m "fix(media): batch MediaStore write requests"
+```

--- a/docs/superpowers/specs/2026-07-20-mediastore-write-request-limit-design.md
+++ b/docs/superpowers/specs/2026-07-20-mediastore-write-request-limit-design.md
@@ -1,0 +1,44 @@
+# MediaStore Write Request Limit Design
+
+## Problem
+
+`LocalMediaOperationsService.moveMedia()` collects every MediaStore URI in a move and passes the complete list to `MediaStore.createWriteRequest()`. Android rejects requests containing more than 2,000 URIs with `IllegalArgumentException`, so a move of 2,001 or more MediaStore items crashes before the system consent dialog can be shown.
+
+The same service already avoids this platform limit for delete requests through `runMediaRequests()`, but write-access requests bypass that runner.
+
+## Desired Behavior
+
+Moves containing more than 2,000 MediaStore URIs request write access in sequential batches of at most 2,000. Once every batch is approved, the existing file move runs unchanged. If any batch is cancelled or rejected, the operation stops requesting further batches and reports every requested move as unsuccessful, matching the current cancellation behavior.
+
+Duplicate URIs should not produce duplicate consent entries. Media items that disappear before the request is created should be removed from the affected batch and the request retried, matching delete-request handling.
+
+## Approaches Considered
+
+1. **Reuse `runMediaRequests()` for write access (selected).** This applies the existing, tested 2,000-item batching, deduplication, stale-item filtering, and early-stop behavior to write requests with a small service change.
+2. **Add write-specific batching inside `requestWriteAccessR()`.** This would work but duplicate the request runner's batching and error-handling logic.
+3. **Reject moves over 2,000 items.** This avoids the crash but needlessly prevents a supported operation and provides worse behavior than sequential system dialogs.
+
+## Design
+
+Route `requestWriteAccessR()` through `runMediaRequests()`. The runner receives the requested URIs, uses the existing `mediaExists()` provider query when recovering from `IllegalArgumentException`, and invokes a new single-batch suspending function that launches one `MediaStore.createWriteRequest()` consent dialog.
+
+The runner processes each batch sequentially, so the service's existing single pair of activity-result callbacks cannot be overwritten by concurrent dialogs. `moveMedia()` continues to wait for the aggregate Boolean result before renaming any files.
+
+No changes are needed to `launchWriteRequest()`, delete handling, rename handling, or the move result type.
+
+## Error Handling
+
+- A cancelled consent dialog returns `false`, stops later batches, and preserves the current all-failed move result.
+- An `IllegalArgumentException` caused by stale URIs triggers the runner's existing existence check and retries only the remaining items.
+- An `IllegalArgumentException` where every URI still exists returns `false` rather than crashing.
+- Coroutine cancellation continues to cancel the suspended request through `suspendCancellableCoroutine`.
+
+## Testing
+
+Extend the JVM tests for `runMediaRequests()` with a write-access-shaped regression test proving that 2,001 URIs produce sequential batches of 2,000 and 1, and that both approvals are required for success. Existing runner tests continue to cover deduplication-adjacent batching, stale-item recovery, and provider rejection.
+
+Run the focused runner tests, the complete core-media unit test suite, and app Kotlin compilation.
+
+## Scope
+
+This change is limited to write access requested by `moveMedia()` on Android 11 and later. It does not redesign the consent UI, partially move files after cancellation, or alter copy/move behavior through the Storage Access Framework.


### PR DESCRIPTION
## Summary

- batch MediaStore write-access requests into at most 2,000 distinct URIs
- reuse the existing stale-item recovery and cancellation behavior
- add a regression test covering a 2,001-item write request

## Testing

- `./gradlew :core:media:testDebugUnitTest :app:compileDebugKotlin`
- 8 core-media tests passed
- app Kotlin compilation passed