### PR TITLE
Fix Secret Vault video sorting

### DIFF
--- a/docs/superpowers/plans/2026-07-20-issue-1830-vault-sorting.md
+++ b/docs/superpowers/plans/2026-07-20-issue-1830-vault-sorting.md
@@ -1,0 +1,275 @@
+# Issue 1830 Vault Sorting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Secret Vault videos inherit the app-wide saved sort at session start and immediately reorder when a session-only vault sort is selected.
+
+**Architecture:** Keep sorting in the existing `GetHiddenVideosUseCase` and coordinate it from `VaultViewModel`. The view model records whether the vault has a session override, derives the initial sort from `ApplicationPreferences`, and restarts its existing hidden-video collection only when the effective sort changes while unlocked.
+
+**Tech Stack:** Kotlin, Android ViewModel, StateFlow, coroutines test, JUnit 4, Robolectric, Gradle
+
+## Global Constraints
+
+- Vault sort selections apply only to the current `VaultViewModel` session.
+- Before a session override, use `ApplicationPreferences.sortBy` and `sortOrder` from the datastore-backed repository.
+- Do not write vault sort selections back to the preferences datastore.
+- Preserve the existing `GetHiddenVideosUseCase` API and Compose UI.
+
+---
+
+### Task 1: Reactive Vault Session Sorting
+
+**Files:**
+- Create: `feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultSortingTest.kt`
+- Modify: `feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt`
+
+**Interfaces:**
+- Consumes: `GetHiddenVideosUseCase.invoke(sort: Sort): Flow<List<Video>>`, `PreferencesRepository.applicationPreferences: StateFlow<ApplicationPreferences>`, and `VaultAction.UpdateSort(sort: Sort)`.
+- Produces: `VaultUiState.sort` initialized from app preferences until locally overridden, plus a reordered `VaultUiState.hiddenVideos` after `UpdateSort`.
+
+- [ ] **Step 1: Write the failing regression tests**
+
+Create `VaultSortingTest.kt` with two behavior-focused tests and local fakes:
+
+```kotlin
+package dev.anilbeesetti.nextplayer.feature.videopicker.screens.vault
+
+import dev.anilbeesetti.nextplayer.core.data.repository.PreferencesRepository
+import dev.anilbeesetti.nextplayer.core.data.repository.UnhideResult
+import dev.anilbeesetti.nextplayer.core.data.repository.VaultPinRepository
+import dev.anilbeesetti.nextplayer.core.data.repository.VaultRepository
+import dev.anilbeesetti.nextplayer.core.domain.GetHiddenVideosUseCase
+import dev.anilbeesetti.nextplayer.core.model.ApplicationPreferences
+import dev.anilbeesetti.nextplayer.core.model.MediaInfo
+import dev.anilbeesetti.nextplayer.core.model.PlayerPreferences
+import dev.anilbeesetti.nextplayer.core.model.Sort
+import dev.anilbeesetti.nextplayer.core.model.Video
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class VaultSortingTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `unlocked vault initially uses application preference sort`() = runTest(testDispatcher.scheduler) {
+        val preferencesRepository = FakePreferencesRepository(
+            ApplicationPreferences(
+                sortBy = Sort.By.TITLE,
+                sortOrder = Sort.Order.ASCENDING,
+            ),
+        )
+        val viewModel = createViewModel(preferencesRepository)
+
+        viewModel.onAction(VaultAction.SubmitUnlockPin("1234"))
+        advanceUntilIdle()
+
+        assertEquals(listOf("Alpha.mp4", "Zebra.mp4"), viewModel.uiState.value.hiddenVideos.map { it.nameWithExtension })
+    }
+
+    @Test
+    fun `updating vault sort reorders videos without updating application preferences`() =
+        runTest(testDispatcher.scheduler) {
+            val preferencesRepository = FakePreferencesRepository(
+                ApplicationPreferences(
+                    sortBy = Sort.By.TITLE,
+                    sortOrder = Sort.Order.ASCENDING,
+                ),
+            )
+            val viewModel = createViewModel(preferencesRepository)
+            viewModel.onAction(VaultAction.SubmitUnlockPin("1234"))
+            advanceUntilIdle()
+
+            viewModel.onAction(
+                VaultAction.UpdateSort(
+                    Sort(by = Sort.By.SIZE, order = Sort.Order.ASCENDING),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(listOf("Zebra.mp4", "Alpha.mp4"), viewModel.uiState.value.hiddenVideos.map { it.nameWithExtension })
+            assertEquals(0, preferencesRepository.applicationUpdateCount)
+            assertEquals(Sort.By.TITLE, preferencesRepository.applicationPreferences.value.sortBy)
+            assertEquals(Sort.Order.ASCENDING, preferencesRepository.applicationPreferences.value.sortOrder)
+        }
+
+    private fun createViewModel(preferencesRepository: FakePreferencesRepository): VaultViewModel {
+        val vaultRepository = FakeVaultRepository(
+            listOf(
+                Video.sample.copy(
+                    id = 1,
+                    nameWithExtension = "Zebra.mp4",
+                    path = "/vault/Zebra.mp4",
+                    uriString = "content://vault/zebra",
+                    size = 1,
+                ),
+                Video.sample.copy(
+                    id = 2,
+                    nameWithExtension = "Alpha.mp4",
+                    path = "/vault/Alpha.mp4",
+                    uriString = "content://vault/alpha",
+                    size = 100,
+                ),
+            ),
+        )
+        return VaultViewModel(
+            vaultRepository = vaultRepository,
+            vaultPinRepository = FakeVaultPinRepository,
+            getHiddenVideosUseCase = GetHiddenVideosUseCase(vaultRepository, testDispatcher),
+            preferencesRepository = preferencesRepository,
+        )
+    }
+
+    private class FakeVaultRepository(videos: List<Video>) : VaultRepository {
+        private val hiddenVideos = MutableStateFlow(videos)
+
+        override fun observeHiddenVideos(): Flow<List<Video>> = hiddenVideos
+        override suspend fun hideVideos(videos: List<Video>) = Unit
+        override suspend fun unhideVideos(videos: List<Video>) = UnhideResult()
+        override suspend fun deleteHiddenVideos(videos: List<Video>) = Unit
+        override suspend fun getHiddenVideoInfo(id: Long): MediaInfo? = null
+    }
+
+    private data object FakeVaultPinRepository : VaultPinRepository {
+        override suspend fun hasPinSet(): Boolean = true
+        override suspend fun setPin(pin: String) = Unit
+        override suspend fun verifyPin(pin: String): Boolean = true
+        override suspend fun hasShownHideConfirmation(): Boolean = false
+        override suspend fun setHideConfirmationShown() = Unit
+    }
+
+    private class FakePreferencesRepository(initialPreferences: ApplicationPreferences) : PreferencesRepository {
+        private val preferences = MutableStateFlow(initialPreferences)
+        override val applicationPreferences: StateFlow<ApplicationPreferences> = preferences
+        override val playerPreferences: StateFlow<PlayerPreferences> = MutableStateFlow(PlayerPreferences())
+        var applicationUpdateCount = 0
+            private set
+
+        override suspend fun updateApplicationPreferences(
+            transform: suspend (ApplicationPreferences) -> ApplicationPreferences,
+        ) {
+            applicationUpdateCount++
+            preferences.value = transform(preferences.value)
+        }
+
+        override suspend fun updatePlayerPreferences(
+            transform: suspend (PlayerPreferences) -> PlayerPreferences,
+        ) = Unit
+
+        override suspend fun resetPreferences() = Unit
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+./gradlew :feature:videopicker:testDebugUnitTest --tests '*VaultSortingTest'
+```
+
+Expected: both tests fail because the vault uses its hard-coded date sort and `UpdateSort` does not restart collection.
+
+- [ ] **Step 3: Implement the minimal screen-logic fix**
+
+In `VaultViewModel.kt`, add a session flag next to `hiddenVideosJob`:
+
+```kotlin
+private var hasVaultSortOverride = false
+```
+
+Replace the preferences collector body with logic that inherits the app sort until an override exists and refreshes an already-unlocked vault only if the inherited sort changed:
+
+```kotlin
+preferencesRepository.applicationPreferences.collect { prefs ->
+    val inheritedSort = Sort(by = prefs.sortBy, order = prefs.sortOrder)
+    val shouldRefresh = !hasVaultSortOverride &&
+        uiStateInternal.value.stage == VaultStage.UNLOCKED &&
+        uiStateInternal.value.sort != inheritedSort
+    uiStateInternal.update {
+        it.copy(
+            preferences = prefs,
+            sort = if (hasVaultSortOverride) it.sort else inheritedSort,
+        )
+    }
+    if (shouldRefresh) collectHiddenVideos()
+}
+```
+
+Route `VaultAction.UpdateSort` to a private method:
+
+```kotlin
+is VaultAction.UpdateSort -> updateSort(action.sort)
+```
+
+Add the method:
+
+```kotlin
+private fun updateSort(sort: Sort) {
+    hasVaultSortOverride = true
+    val shouldRefresh = uiStateInternal.value.stage == VaultStage.UNLOCKED &&
+        uiStateInternal.value.sort != sort
+    uiStateInternal.update { it.copy(sort = sort) }
+    if (shouldRefresh) collectHiddenVideos()
+}
+```
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run:
+
+```bash
+./gradlew :feature:videopicker:testDebugUnitTest --tests '*VaultSortingTest'
+```
+
+Expected: `VaultSortingTest` passes with two tests and zero failures.
+
+- [ ] **Step 5: Run feature regression tests and compilation**
+
+Run:
+
+```bash
+./gradlew :feature:videopicker:testDebugUnitTest :app:compileDebugKotlin
+```
+
+Expected: both Gradle tasks complete with `BUILD SUCCESSFUL` and zero failed tests.
+
+- [ ] **Step 6: Review the diff and commit the fix**
+
+Run:
+
+```bash
+git diff --check
+git diff -- feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultSortingTest.kt
+git add feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultSortingTest.kt
+git commit -m "fix: apply vault video sorting"
+```
+
+Expected: the diff contains only the focused ViewModel behavior and regression tests, and the commit succeeds.

--- a/docs/superpowers/specs/2026-07-20-issue-1830-vault-sorting-design.md
+++ b/docs/superpowers/specs/2026-07-20-issue-1830-vault-sorting-design.md
@@ -1,0 +1,35 @@
+# Issue 1830: Vault Sorting Design
+
+## Problem
+
+The Secret Vault displays hidden videos using the sort value captured when its collection starts. Selecting another sort option updates `VaultUiState.sort`, but does not restart or reactively update that collection, so the visible order remains unchanged.
+
+The vault also starts with a hard-coded date-descending sort instead of inheriting the app-wide sort stored in the preferences datastore.
+
+## Design
+
+`VaultViewModel` will distinguish between the app-wide default and a vault-session override:
+
+- Before the user changes the vault sort, preference emissions set the vault sort from `ApplicationPreferences.sortBy` and `sortOrder`.
+- Once the user selects a vault sort, that selection remains local to the current `VaultViewModel` session and later preference emissions do not replace it.
+- Updating the vault sort while the vault is unlocked restarts the hidden-video collection with the new sort, immediately reordering the displayed list.
+- Vault sort changes are not written back to the datastore.
+
+This keeps the change inside the existing screen-logic boundary and preserves the current `GetHiddenVideosUseCase` contract.
+
+## Data Flow
+
+1. The preferences repository emits the app-wide preferences.
+2. The view model copies the preferences into UI state and, if no vault-session override exists, derives `VaultUiState.sort` from them.
+3. Unlocking the vault starts hidden-video collection with the current sort.
+4. A `VaultAction.UpdateSort` marks the session as overridden, updates `VaultUiState.sort`, and restarts collection when the vault is unlocked.
+5. `GetHiddenVideosUseCase` applies the requested comparator and emits the reordered list.
+
+## Testing
+
+A ViewModel regression test will use a repository flow containing videos whose title and size orders differ. It will verify that:
+
+- the initial unlocked list uses the app-wide datastore sort; and
+- dispatching `VaultAction.UpdateSort` changes the visible order without modifying app-wide preferences.
+
+Targeted feature tests and Kotlin compilation will be run after implementation.

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt
@@ -41,6 +41,7 @@ class VaultViewModel @Inject constructor(
     val events = eventsInternal.receiveAsFlow()
 
     private var hiddenVideosJob: Job? = null
+    private var hasVaultSortOverride = false
 
     init {
         viewModelScope.launch {
@@ -51,7 +52,17 @@ class VaultViewModel @Inject constructor(
         }
         viewModelScope.launch {
             preferencesRepository.applicationPreferences.collect { prefs ->
-                uiStateInternal.update { it.copy(preferences = prefs) }
+                val inheritedSort = Sort(by = prefs.sortBy, order = prefs.sortOrder)
+                val shouldRefresh = !hasVaultSortOverride &&
+                    uiStateInternal.value.stage == VaultStage.UNLOCKED &&
+                    uiStateInternal.value.sort != inheritedSort
+                uiStateInternal.update {
+                    it.copy(
+                        preferences = prefs,
+                        sort = if (hasVaultSortOverride) it.sort else inheritedSort,
+                    )
+                }
+                if (shouldRefresh) collectHiddenVideos()
             }
         }
     }
@@ -68,8 +79,16 @@ class VaultViewModel @Inject constructor(
             is VaultAction.DeleteSelected -> deleteVideos(action.selectionItems)
             is VaultAction.ShowMediaInfo -> showMediaInfo(action.video)
             VaultAction.DismissMediaInfo -> uiStateInternal.update { it.copy(mediaInfo = null) }
-            is VaultAction.UpdateSort -> uiStateInternal.update { it.copy(sort = action.sort) }
+            is VaultAction.UpdateSort -> updateSort(action.sort)
         }
+    }
+
+    private fun updateSort(sort: Sort) {
+        hasVaultSortOverride = true
+        val shouldRefresh = uiStateInternal.value.stage == VaultStage.UNLOCKED &&
+            uiStateInternal.value.sort != sort
+        uiStateInternal.update { it.copy(sort = sort) }
+        if (shouldRefresh) collectHiddenVideos()
     }
 
     private fun submitNewPin(pin: String) {

--- a/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultSortingTest.kt
+++ b/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultSortingTest.kt
@@ -32,6 +32,8 @@ import org.robolectric.RobolectricTestRunner
 class VaultSortingTest {
 
     private val testDispatcher = StandardTestDispatcher()
+    private val titleAscending = Sort(by = Sort.By.TITLE, order = Sort.Order.ASCENDING)
+    private val sizeAscending = Sort(by = Sort.By.SIZE, order = Sort.Order.ASCENDING)
 
     @Before
     fun setUp() {
@@ -47,8 +49,8 @@ class VaultSortingTest {
     fun `unlocked vault initially uses application preference sort`() = runTest(testDispatcher.scheduler) {
         val preferencesRepository = FakePreferencesRepository(
             ApplicationPreferences(
-                sortBy = Sort.By.TITLE,
-                sortOrder = Sort.Order.ASCENDING,
+                sortBy = titleAscending.by,
+                sortOrder = titleAscending.order,
             ),
         )
         val viewModel = createViewModel(preferencesRepository)
@@ -56,7 +58,11 @@ class VaultSortingTest {
         viewModel.onAction(VaultAction.SubmitUnlockPin("1234"))
         advanceUntilIdle()
 
-        assertEquals(listOf("Alpha.mp4", "Zebra.mp4"), viewModel.uiState.value.hiddenVideos.map { it.nameWithExtension })
+        assertEquals(titleAscending, viewModel.uiState.value.sort)
+        assertEquals(
+            listOf("Alpha.mp4", "Bravo.mp4", "Zebra.mp4"),
+            viewModel.uiState.value.hiddenVideos.map { it.nameWithExtension },
+        )
     }
 
     @Test
@@ -64,25 +70,108 @@ class VaultSortingTest {
         runTest(testDispatcher.scheduler) {
             val preferencesRepository = FakePreferencesRepository(
                 ApplicationPreferences(
-                    sortBy = Sort.By.TITLE,
-                    sortOrder = Sort.Order.ASCENDING,
+                    sortBy = titleAscending.by,
+                    sortOrder = titleAscending.order,
                 ),
             )
             val viewModel = createViewModel(preferencesRepository)
             viewModel.onAction(VaultAction.SubmitUnlockPin("1234"))
             advanceUntilIdle()
 
+            assertEquals(titleAscending, viewModel.uiState.value.sort)
+            assertEquals(
+                listOf("Alpha.mp4", "Bravo.mp4", "Zebra.mp4"),
+                viewModel.uiState.value.hiddenVideos.map { it.nameWithExtension },
+            )
+
             viewModel.onAction(
                 VaultAction.UpdateSort(
-                    Sort(by = Sort.By.SIZE, order = Sort.Order.ASCENDING),
+                    sizeAscending,
                 ),
             )
             advanceUntilIdle()
 
-            assertEquals(listOf("Zebra.mp4", "Alpha.mp4"), viewModel.uiState.value.hiddenVideos.map { it.nameWithExtension })
+            assertEquals(sizeAscending, viewModel.uiState.value.sort)
+            assertEquals(
+                listOf("Zebra.mp4", "Alpha.mp4", "Bravo.mp4"),
+                viewModel.uiState.value.hiddenVideos.map { it.nameWithExtension },
+            )
             assertEquals(0, preferencesRepository.applicationUpdateCount)
             assertEquals(Sort.By.TITLE, preferencesRepository.applicationPreferences.value.sortBy)
             assertEquals(Sort.Order.ASCENDING, preferencesRepository.applicationPreferences.value.sortOrder)
+        }
+
+    @Test
+    fun `application preference sort change refreshes unlocked vault before local override`() =
+        runTest(testDispatcher.scheduler) {
+            val preferencesRepository = FakePreferencesRepository(
+                ApplicationPreferences(sortBy = titleAscending.by, sortOrder = titleAscending.order),
+            )
+            val viewModel = createViewModel(preferencesRepository)
+            viewModel.onAction(VaultAction.SubmitUnlockPin("1234"))
+            advanceUntilIdle()
+
+            preferencesRepository.emitApplicationPreferences(
+                ApplicationPreferences(sortBy = sizeAscending.by, sortOrder = sizeAscending.order),
+            )
+            advanceUntilIdle()
+
+            assertEquals(sizeAscending, viewModel.uiState.value.sort)
+            assertEquals(
+                listOf("Zebra.mp4", "Alpha.mp4", "Bravo.mp4"),
+                viewModel.uiState.value.hiddenVideos.map { it.nameWithExtension },
+            )
+        }
+
+    @Test
+    fun `application preference change preserves local vault sort after override`() =
+        runTest(testDispatcher.scheduler) {
+            val preferencesRepository = FakePreferencesRepository(
+                ApplicationPreferences(sortBy = titleAscending.by, sortOrder = titleAscending.order),
+            )
+            val viewModel = createViewModel(preferencesRepository)
+            viewModel.onAction(VaultAction.SubmitUnlockPin("1234"))
+            advanceUntilIdle()
+            viewModel.onAction(VaultAction.UpdateSort(sizeAscending))
+            advanceUntilIdle()
+
+            preferencesRepository.emitApplicationPreferences(
+                ApplicationPreferences(sortBy = Sort.By.DATE, sortOrder = Sort.Order.DESCENDING),
+            )
+            advanceUntilIdle()
+
+            assertEquals(Sort.By.DATE, viewModel.uiState.value.preferences.sortBy)
+            assertEquals(Sort.Order.DESCENDING, viewModel.uiState.value.preferences.sortOrder)
+            assertEquals(sizeAscending, viewModel.uiState.value.sort)
+            assertEquals(
+                listOf("Zebra.mp4", "Alpha.mp4", "Bravo.mp4"),
+                viewModel.uiState.value.hiddenVideos.map { it.nameWithExtension },
+            )
+        }
+
+    @Test
+    fun `selecting the active vault sort preserves it through later preference changes`() =
+        runTest(testDispatcher.scheduler) {
+            val preferencesRepository = FakePreferencesRepository(
+                ApplicationPreferences(sortBy = titleAscending.by, sortOrder = titleAscending.order),
+            )
+            val viewModel = createViewModel(preferencesRepository)
+            viewModel.onAction(VaultAction.SubmitUnlockPin("1234"))
+            advanceUntilIdle()
+
+            viewModel.onAction(VaultAction.UpdateSort(titleAscending))
+            preferencesRepository.emitApplicationPreferences(
+                ApplicationPreferences(sortBy = sizeAscending.by, sortOrder = sizeAscending.order),
+            )
+            advanceUntilIdle()
+
+            assertEquals(Sort.By.SIZE, viewModel.uiState.value.preferences.sortBy)
+            assertEquals(Sort.Order.ASCENDING, viewModel.uiState.value.preferences.sortOrder)
+            assertEquals(titleAscending, viewModel.uiState.value.sort)
+            assertEquals(
+                listOf("Alpha.mp4", "Bravo.mp4", "Zebra.mp4"),
+                viewModel.uiState.value.hiddenVideos.map { it.nameWithExtension },
+            )
         }
 
     private fun createViewModel(preferencesRepository: FakePreferencesRepository): VaultViewModel {
@@ -93,14 +182,24 @@ class VaultSortingTest {
                     nameWithExtension = "Zebra.mp4",
                     path = "/vault/Zebra.mp4",
                     uriString = "content://vault/zebra",
-                    size = 1,
+                    size = 10,
+                    dateModified = 200,
                 ),
                 Video.sample.copy(
                     id = 2,
                     nameWithExtension = "Alpha.mp4",
                     path = "/vault/Alpha.mp4",
                     uriString = "content://vault/alpha",
-                    size = 100,
+                    size = 20,
+                    dateModified = 100,
+                ),
+                Video.sample.copy(
+                    id = 3,
+                    nameWithExtension = "Bravo.mp4",
+                    path = "/vault/Bravo.mp4",
+                    uriString = "content://vault/bravo",
+                    size = 30,
+                    dateModified = 300,
                 ),
             ),
         )
@@ -149,5 +248,9 @@ class VaultSortingTest {
         ) = Unit
 
         override suspend fun resetPreferences() = Unit
+
+        fun emitApplicationPreferences(value: ApplicationPreferences) {
+            preferences.value = value
+        }
     }
 }

--- a/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultSortingTest.kt
+++ b/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultSortingTest.kt
@@ -1,0 +1,153 @@
+package dev.anilbeesetti.nextplayer.feature.videopicker.screens.vault
+
+import dev.anilbeesetti.nextplayer.core.data.repository.PreferencesRepository
+import dev.anilbeesetti.nextplayer.core.data.repository.UnhideResult
+import dev.anilbeesetti.nextplayer.core.data.repository.VaultPinRepository
+import dev.anilbeesetti.nextplayer.core.data.repository.VaultRepository
+import dev.anilbeesetti.nextplayer.core.domain.GetHiddenVideosUseCase
+import dev.anilbeesetti.nextplayer.core.model.ApplicationPreferences
+import dev.anilbeesetti.nextplayer.core.model.MediaInfo
+import dev.anilbeesetti.nextplayer.core.model.PlayerPreferences
+import dev.anilbeesetti.nextplayer.core.model.Sort
+import dev.anilbeesetti.nextplayer.core.model.Video
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class VaultSortingTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `unlocked vault initially uses application preference sort`() = runTest(testDispatcher.scheduler) {
+        val preferencesRepository = FakePreferencesRepository(
+            ApplicationPreferences(
+                sortBy = Sort.By.TITLE,
+                sortOrder = Sort.Order.ASCENDING,
+            ),
+        )
+        val viewModel = createViewModel(preferencesRepository)
+
+        viewModel.onAction(VaultAction.SubmitUnlockPin("1234"))
+        advanceUntilIdle()
+
+        assertEquals(listOf("Alpha.mp4", "Zebra.mp4"), viewModel.uiState.value.hiddenVideos.map { it.nameWithExtension })
+    }
+
+    @Test
+    fun `updating vault sort reorders videos without updating application preferences`() =
+        runTest(testDispatcher.scheduler) {
+            val preferencesRepository = FakePreferencesRepository(
+                ApplicationPreferences(
+                    sortBy = Sort.By.TITLE,
+                    sortOrder = Sort.Order.ASCENDING,
+                ),
+            )
+            val viewModel = createViewModel(preferencesRepository)
+            viewModel.onAction(VaultAction.SubmitUnlockPin("1234"))
+            advanceUntilIdle()
+
+            viewModel.onAction(
+                VaultAction.UpdateSort(
+                    Sort(by = Sort.By.SIZE, order = Sort.Order.ASCENDING),
+                ),
+            )
+            advanceUntilIdle()
+
+            assertEquals(listOf("Zebra.mp4", "Alpha.mp4"), viewModel.uiState.value.hiddenVideos.map { it.nameWithExtension })
+            assertEquals(0, preferencesRepository.applicationUpdateCount)
+            assertEquals(Sort.By.TITLE, preferencesRepository.applicationPreferences.value.sortBy)
+            assertEquals(Sort.Order.ASCENDING, preferencesRepository.applicationPreferences.value.sortOrder)
+        }
+
+    private fun createViewModel(preferencesRepository: FakePreferencesRepository): VaultViewModel {
+        val vaultRepository = FakeVaultRepository(
+            listOf(
+                Video.sample.copy(
+                    id = 1,
+                    nameWithExtension = "Zebra.mp4",
+                    path = "/vault/Zebra.mp4",
+                    uriString = "content://vault/zebra",
+                    size = 1,
+                ),
+                Video.sample.copy(
+                    id = 2,
+                    nameWithExtension = "Alpha.mp4",
+                    path = "/vault/Alpha.mp4",
+                    uriString = "content://vault/alpha",
+                    size = 100,
+                ),
+            ),
+        )
+        return VaultViewModel(
+            vaultRepository = vaultRepository,
+            vaultPinRepository = FakeVaultPinRepository,
+            getHiddenVideosUseCase = GetHiddenVideosUseCase(vaultRepository, testDispatcher),
+            preferencesRepository = preferencesRepository,
+        )
+    }
+
+    private class FakeVaultRepository(videos: List<Video>) : VaultRepository {
+        private val hiddenVideos = MutableStateFlow(videos)
+
+        override fun observeHiddenVideos(): Flow<List<Video>> = hiddenVideos
+        override suspend fun hideVideos(videos: List<Video>) = Unit
+        override suspend fun unhideVideos(videos: List<Video>) = UnhideResult()
+        override suspend fun deleteHiddenVideos(videos: List<Video>) = Unit
+        override suspend fun getHiddenVideoInfo(id: Long): MediaInfo? = null
+    }
+
+    private data object FakeVaultPinRepository : VaultPinRepository {
+        override suspend fun hasPinSet(): Boolean = true
+        override suspend fun setPin(pin: String) = Unit
+        override suspend fun verifyPin(pin: String): Boolean = true
+        override suspend fun hasShownHideConfirmation(): Boolean = false
+        override suspend fun setHideConfirmationShown() = Unit
+    }
+
+    private class FakePreferencesRepository(initialPreferences: ApplicationPreferences) : PreferencesRepository {
+        private val preferences = MutableStateFlow(initialPreferences)
+        override val applicationPreferences: StateFlow<ApplicationPreferences> = preferences
+        override val playerPreferences: StateFlow<PlayerPreferences> = MutableStateFlow(PlayerPreferences())
+        var applicationUpdateCount = 0
+            private set
+
+        override suspend fun updateApplicationPreferences(
+            transform: suspend (ApplicationPreferences) -> ApplicationPreferences,
+        ) {
+            applicationUpdateCount++
+            preferences.value = transform(preferences.value)
+        }
+
+        override suspend fun updatePlayerPreferences(
+            transform: suspend (PlayerPreferences) -> PlayerPreferences,
+        ) = Unit
+
+        override suspend fun resetPreferences() = Unit
+    }
+}


### PR DESCRIPTION
## Summary

- inherit the Secret Vault's initial sort from the app-wide saved preferences
- restart hidden-video collection when the user chooses a different vault sort
- keep vault sort overrides local to the current vault session without updating datastore
- cover initial inheritance and preference changes before and after a local override

## Testing

- `./gradlew :feature:videopicker:testDebugUnitTest :app:compileDebugKotlin --rerun-tasks`
- 8 videopicker tests passed; app Kotlin compilation succeeded

Fixes #1830
