### PR TITLE
Fix oversized crash report clipboard copy

### DIFF
--- a/.superpowers/sdd/task-1-report.md
+++ b/.superpowers/sdd/task-1-report.md
@@ -1,0 +1,57 @@
+# Task 1 Report: Bound crash reports before clipboard IPC
+
+## Implementation
+
+- Added `CrashLogClipboard.kt` with a 100,000 UTF-16-character clipboard boundary and the required truncation marker: `\n\n[Crash report truncated. Use Share for full logs.]`.
+- Added `crashReportForClipboard(report)` to preserve reports at or below the boundary and preserve the report prefix plus marker for oversized reports.
+- Added `copyCrashReportToClipboard(clipboard, report)` to create the bounded `ClipData` payload.
+- Routed only `CrashActivity`'s Copy callback through that helper. The existing Share callback and `concatLogs` implementation remain unchanged, so Share continues to write the complete report to a cache file and expose it through a content URI.
+- Configured `androidx.test.runner.AndroidJUnitRunner` in the app default config.
+
+## Files
+
+- `app/build.gradle.kts`
+- `app/src/main/java/dev/anilbeesetti/nextplayer/crash/CrashActivity.kt`
+- `app/src/main/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboard.kt`
+- `app/src/test/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboardTest.kt`
+- `app/src/androidTest/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboardInstrumentedTest.kt`
+- `docs/superpowers/specs/2026-07-20-issue-1828-crash-log-clipboard-design.md`
+- `docs/superpowers/plans/2026-07-20-issue-1828-crash-log-clipboard.md`
+
+## TDD evidence
+
+### RED
+
+1. `ANDROID_SERIAL=emulator-5554 ANDROID_HOME=/Users/anil/Library/Android/sdk ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk ./gradlew :app:testDebugUnitTest --tests dev.anilbeesetti.nextplayer.crash.CrashLogClipboardTest`
+   - Failed as expected at `:app:compileDebugUnitTestKotlin` because `MAX_CLIPBOARD_REPORT_CHARS`, `CLIPBOARD_REPORT_TRUNCATION_MARKER`, and `crashReportForClipboard` were unresolved.
+2. `ANDROID_SERIAL=emulator-5554 ANDROID_HOME=/Users/anil/Library/Android/sdk ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.anilbeesetti.nextplayer.crash.CrashLogClipboardInstrumentedTest`
+   - Failed as expected at `:app:compileDebugAndroidTestKotlin` because `copyCrashReportToClipboard`, `MAX_CLIPBOARD_REPORT_CHARS`, and `CLIPBOARD_REPORT_TRUNCATION_MARKER` were unresolved.
+
+### GREEN
+
+1. `ANDROID_SERIAL=emulator-5554 ANDROID_HOME=/Users/anil/Library/Android/sdk ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk ./gradlew :app:testDebugUnitTest --tests dev.anilbeesetti.nextplayer.crash.CrashLogClipboardTest`
+   - Passed: 2/2 JVM tests.
+2. `ANDROID_SERIAL=emulator-5554 ANDROID_HOME=/Users/anil/Library/Android/sdk ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.anilbeesetti.nextplayer.crash.CrashLogClipboardInstrumentedTest`
+   - Passed on `emulator-5554` (API 36): the 2,596,638-character source report copied without `TransactionTooLargeException` and read back as exactly 100,000 characters with the required prefix and marker.
+
+The initial implementation-test read-back failed with `expected:<100000> but was:<4>` because Android 16's `ClipboardService` denied reads from the non-focused test app. The emulator log confirmed: `Denying clipboard access to dev.anilbeesetti.nextplayer.debug, application is not in focus nor is it a system service`. Launching `MainActivity` did not address this because its runtime-permission dialog took focus. The final test launches `CrashActivity` with a synthetic exception before copying; that provides an in-app foreground host without invoking the permission dialog. This is test setup only and does not alter production behavior.
+
+## Regression/build verification
+
+`ANDROID_SERIAL=emulator-5554 ANDROID_HOME=/Users/anil/Library/Android/sdk ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk ./gradlew :app:testDebugUnitTest :feature:videopicker:testDebugUnitTest :core:domain:testDebugUnitTest :core:media:testDebugUnitTest :core:model:test :app:assembleDebug`
+
+- Result: `BUILD SUCCESSFUL`.
+- The output includes both `CrashLogClipboardTest` cases passing; all requested module test tasks and `:app:assembleDebug` completed successfully.
+
+## Self-review
+
+- Confirmed the helper has the exact required limit and marker, and includes the marker in the 100,000-character limit.
+- Confirmed the oversized path retains the beginning of the report and ends with the marker; the exact-boundary path returns the original string.
+- Confirmed only the Copy callback changed; `shareLogs` and `concatLogs` are unchanged.
+- Confirmed the instrumentation test sends the supplied approximately 5.2 MB payload through the real API-36 clipboard and verifies bounded content.
+- Ran `git diff --check`: no whitespace errors.
+
+## Concerns
+
+- Gradle emits existing configuration-time dependency-resolution warnings (Gradle issue 2298) during all test/build commands; they did not affect task outcomes.
+- The API-36 instrumentation assertion requires a foreground app because Android blocks background clipboard reads. The test launches `CrashActivity` solely for that platform requirement.

--- a/.superpowers/sdd/task-1-report.md
+++ b/.superpowers/sdd/task-1-report.md
@@ -55,3 +55,20 @@ The initial implementation-test read-back failed with `expected:<100000> but was
 
 - Gradle emits existing configuration-time dependency-resolution warnings (Gradle issue 2298) during all test/build commands; they did not affect task outcomes.
 - The API-36 instrumentation assertion requires a foreground app because Android blocks background clipboard reads. The test launches `CrashActivity` solely for that platform requirement.
+
+## Follow-up: deterministic API-36 clipboard focus synchronization
+
+Whole-branch review found that the original instrumentation setup used `context.startActivity(...)` followed by `SystemClock.sleep(1_000)`. That delay did not prove that `CrashActivity` had resumed or received window focus before the API-36 clipboard read-back. The test now launches `CrashActivity` with `ActivityScenario.launch`, scopes it with `use` so the activity is closed, and calls `awaitWindowFocus()` before copying. The helper polls `hasWindowFocus()` on the main thread, drains the instrumentation queue between checks, and fails after a five-second deadline; it contains no fixed sleep. Production code is unchanged.
+
+### Follow-up RED
+
+`ANDROID_SERIAL=emulator-5554 ANDROID_HOME=/Users/anil/Library/Android/sdk ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.anilbeesetti.nextplayer.crash.CrashLogClipboardInstrumentedTest`
+
+- Failed as expected at `:app:compileDebugAndroidTestKotlin`: the renamed focused-activity regression referenced the intentionally absent `awaitWindowFocus` helper.
+
+### Follow-up GREEN
+
+1. `ANDROID_SERIAL=emulator-5554 ANDROID_HOME=/Users/anil/Library/Android/sdk ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.anilbeesetti.nextplayer.crash.CrashLogClipboardInstrumentedTest`
+   - Passed on `emulator-5554` (API 36) after `ActivityScenario` lifecycle and window-focus synchronization.
+2. `ANDROID_SERIAL=emulator-5554 ANDROID_HOME=/Users/anil/Library/Android/sdk ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk ./gradlew :app:testDebugUnitTest --tests dev.anilbeesetti.nextplayer.crash.CrashLogClipboardTest`
+   - Passed; no production code changed in this follow-up.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,7 @@ android {
         applicationId = "dev.anilbeesetti.nextplayer"
         versionCode = 70
         versionName = "0.17.3"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildFeatures {

--- a/app/src/androidTest/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboardInstrumentedTest.kt
+++ b/app/src/androidTest/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboardInstrumentedTest.kt
@@ -1,0 +1,43 @@
+package dev.anilbeesetti.nextplayer.crash
+
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.os.SystemClock
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@SdkSuppress(minSdkVersion = 36, maxSdkVersion = 36)
+class CrashLogClipboardInstrumentedTest {
+
+    @Test
+    fun reportedFiveMegabytePayloadDoesNotCrashClipboardCopy() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val clipboard = context.getSystemService(ClipboardManager::class.java)
+        val prefix = "Primary hide failure\n"
+        val report = prefix + "x".repeat(2_596_638)
+
+        context.startActivity(
+            Intent(context, CrashActivity::class.java)
+                .putExtra("exception", "test")
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        )
+        SystemClock.sleep(1_000)
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            copyCrashReportToClipboard(clipboard, report)
+        }
+
+        val copied = clipboard.primaryClip?.getItemAt(0)?.text.toString()
+        assertEquals(MAX_CLIPBOARD_REPORT_CHARS, copied.length)
+        assertTrue(copied.startsWith(prefix))
+        assertTrue(copied.endsWith(CLIPBOARD_REPORT_TRUNCATION_MARKER))
+    }
+}

--- a/app/src/androidTest/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboardInstrumentedTest.kt
+++ b/app/src/androidTest/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboardInstrumentedTest.kt
@@ -4,6 +4,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.os.SystemClock
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SdkSuppress
@@ -13,31 +14,54 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
+private const val WINDOW_FOCUS_TIMEOUT_MS = 5_000L
+
 @RunWith(AndroidJUnit4::class)
 @SdkSuppress(minSdkVersion = 36, maxSdkVersion = 36)
 class CrashLogClipboardInstrumentedTest {
 
     @Test
-    fun reportedFiveMegabytePayloadDoesNotCrashClipboardCopy() {
+    fun reportedFiveMegabytePayloadCopiesWhenCrashActivityHasWindowFocus() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val clipboard = context.getSystemService(ClipboardManager::class.java)
         val prefix = "Primary hide failure\n"
         val report = prefix + "x".repeat(2_596_638)
 
-        context.startActivity(
+        ActivityScenario.launch<CrashActivity>(
             Intent(context, CrashActivity::class.java)
                 .putExtra("exception", "test")
-                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-        )
-        SystemClock.sleep(1_000)
+        ).use { scenario ->
+            scenario.awaitWindowFocus()
 
-        InstrumentationRegistry.getInstrumentation().runOnMainSync {
-            copyCrashReportToClipboard(clipboard, report)
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                copyCrashReportToClipboard(clipboard, report)
+            }
+
+            val copied = clipboard.primaryClip?.getItemAt(0)?.text.toString()
+            assertEquals(MAX_CLIPBOARD_REPORT_CHARS, copied.length)
+            assertTrue(copied.startsWith(prefix))
+            assertTrue(copied.endsWith(CLIPBOARD_REPORT_TRUNCATION_MARKER))
         }
-
-        val copied = clipboard.primaryClip?.getItemAt(0)?.text.toString()
-        assertEquals(MAX_CLIPBOARD_REPORT_CHARS, copied.length)
-        assertTrue(copied.startsWith(prefix))
-        assertTrue(copied.endsWith(CLIPBOARD_REPORT_TRUNCATION_MARKER))
     }
+}
+
+private fun ActivityScenario<CrashActivity>.awaitWindowFocus() {
+    val instrumentation = InstrumentationRegistry.getInstrumentation()
+    val deadline = SystemClock.uptimeMillis() + WINDOW_FOCUS_TIMEOUT_MS
+
+    while (SystemClock.uptimeMillis() < deadline) {
+        var hasWindowFocus = false
+        onActivity { activity ->
+            hasWindowFocus = activity.hasWindowFocus()
+        }
+        if (hasWindowFocus) return
+
+        instrumentation.waitForIdleSync()
+    }
+
+    var hasWindowFocus = false
+    onActivity { activity ->
+        hasWindowFocus = activity.hasWindowFocus()
+    }
+    assertTrue("CrashActivity did not receive window focus", hasWindowFocus)
 }

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/crash/CrashActivity.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/crash/CrashActivity.kt
@@ -140,11 +140,9 @@ class CrashActivity : ComponentActivity() {
                         }
                     },
                     onCopyLogsClick = {
-                        clipboard.nativeClipboard.setPrimaryClip(
-                            ClipData.newPlainText(
-                                null,
-                                concatLogs(collectDeviceInfo(), exceptionString, logcat),
-                            ),
+                        copyCrashReportToClipboard(
+                            clipboard = clipboard.nativeClipboard,
+                            report = concatLogs(collectDeviceInfo(), exceptionString, logcat),
                         )
                     },
                     onRestartClick = {

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboard.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboard.kt
@@ -1,0 +1,24 @@
+package dev.anilbeesetti.nextplayer.crash
+
+import android.content.ClipData
+import android.content.ClipboardManager
+
+internal const val MAX_CLIPBOARD_REPORT_CHARS = 100_000
+internal const val CLIPBOARD_REPORT_TRUNCATION_MARKER =
+    "\n\n[Crash report truncated. Use Share for full logs.]"
+
+internal fun crashReportForClipboard(report: String): String {
+    if (report.length <= MAX_CLIPBOARD_REPORT_CHARS) return report
+
+    val prefixLength = MAX_CLIPBOARD_REPORT_CHARS - CLIPBOARD_REPORT_TRUNCATION_MARKER.length
+    return report.take(prefixLength) + CLIPBOARD_REPORT_TRUNCATION_MARKER
+}
+
+internal fun copyCrashReportToClipboard(
+    clipboard: ClipboardManager,
+    report: String,
+) {
+    clipboard.setPrimaryClip(
+        ClipData.newPlainText(null, crashReportForClipboard(report)),
+    )
+}

--- a/app/src/test/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboardTest.kt
+++ b/app/src/test/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboardTest.kt
@@ -1,0 +1,27 @@
+package dev.anilbeesetti.nextplayer.crash
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CrashLogClipboardTest {
+
+    @Test
+    fun reportAtClipboardLimitIsUnchanged() {
+        val report = "x".repeat(MAX_CLIPBOARD_REPORT_CHARS)
+
+        assertEquals(report, crashReportForClipboard(report))
+    }
+
+    @Test
+    fun oversizedReportRetainsPrefixAndAddsTruncationMarkerWithinLimit() {
+        val prefix = "Device info\nException:\nPrimary hide failure\n"
+        val report = prefix + "x".repeat(MAX_CLIPBOARD_REPORT_CHARS)
+
+        val bounded = crashReportForClipboard(report)
+
+        assertEquals(MAX_CLIPBOARD_REPORT_CHARS, bounded.length)
+        assertTrue(bounded.startsWith(prefix))
+        assertTrue(bounded.endsWith(CLIPBOARD_REPORT_TRUNCATION_MARKER))
+    }
+}

--- a/docs/superpowers/plans/2026-07-20-issue-1828-crash-log-clipboard.md
+++ b/docs/superpowers/plans/2026-07-20-issue-1828-crash-log-clipboard.md
@@ -1,0 +1,203 @@
+# Issue 1828 Crash-Log Clipboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent oversized crash reports from crashing `CrashActivity` when copied while retaining full file-based sharing.
+
+**Architecture:** Add a small app-module helper that bounds clipboard-bound report text before creating `ClipData`. Keep report collection/composition and file-based Share unchanged, and wire only the Copy callback through the helper.
+
+**Tech Stack:** Kotlin, Android ClipboardManager/ClipData, JUnit 4, AndroidX Test, Android 16/API 36 emulator.
+
+## Global Constraints
+
+- Clipboard-bound crash reports must contain at most 100,000 UTF-16 characters, including the truncation marker.
+- The exact truncation marker is `\n\n[Crash report truncated. Use Share for full logs.]`.
+- The report prefix must be retained so device information and the primary exception remain available.
+- Reports at or below the limit must remain byte-for-byte unchanged as Kotlin strings.
+- Full, untruncated logs must remain available through the existing file-based Share action.
+- Vault move behavior, Hide UI behavior, and logcat collection are out of scope.
+
+---
+
+### Task 1: Bound crash reports before clipboard IPC
+
+**Files:**
+- Create: `app/src/main/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboard.kt`
+- Modify: `app/src/main/java/dev/anilbeesetti/nextplayer/crash/CrashActivity.kt:142-149`
+- Modify: `app/build.gradle.kts:15-21`
+- Create: `app/src/test/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboardTest.kt`
+- Create: `app/src/androidTest/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboardInstrumentedTest.kt`
+
+**Interfaces:**
+- Consumes: the complete crash-report `String` already returned by `CrashActivity.concatLogs(...)` and `android.content.ClipboardManager`.
+- Produces: `internal fun crashReportForClipboard(report: String): String` and `internal fun copyCrashReportToClipboard(clipboard: ClipboardManager, report: String)`.
+
+- [ ] **Step 1: Configure and write the failing regression tests**
+
+Add `testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"` to `app/build.gradle.kts` `defaultConfig` so the existing and new Android tests can run.
+
+Create `CrashLogClipboardTest.kt`:
+
+```kotlin
+package dev.anilbeesetti.nextplayer.crash
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CrashLogClipboardTest {
+
+    @Test
+    fun reportAtClipboardLimitIsUnchanged() {
+        val report = "x".repeat(MAX_CLIPBOARD_REPORT_CHARS)
+
+        assertEquals(report, crashReportForClipboard(report))
+    }
+
+    @Test
+    fun oversizedReportRetainsPrefixAndAddsTruncationMarkerWithinLimit() {
+        val prefix = "Device info\nException:\nPrimary hide failure\n"
+        val report = prefix + "x".repeat(MAX_CLIPBOARD_REPORT_CHARS)
+
+        val bounded = crashReportForClipboard(report)
+
+        assertEquals(MAX_CLIPBOARD_REPORT_CHARS, bounded.length)
+        assertTrue(bounded.startsWith(prefix))
+        assertTrue(bounded.endsWith(CLIPBOARD_REPORT_TRUNCATION_MARKER))
+    }
+}
+```
+
+Create `CrashLogClipboardInstrumentedTest.kt`:
+
+```kotlin
+package dev.anilbeesetti.nextplayer.crash
+
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@SdkSuppress(minSdkVersion = 36, maxSdkVersion = 36)
+class CrashLogClipboardInstrumentedTest {
+
+    @Test
+    fun reportedFiveMegabytePayloadDoesNotCrashClipboardCopy() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val clipboard = context.getSystemService(ClipboardManager::class.java)
+        val prefix = "Primary hide failure\n"
+        val report = prefix + "x".repeat(2_596_638)
+
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            copyCrashReportToClipboard(clipboard, report)
+        }
+
+        val copied = clipboard.primaryClip?.getItemAt(0)?.text.toString()
+        assertEquals(MAX_CLIPBOARD_REPORT_CHARS, copied.length)
+        assertTrue(copied.startsWith(prefix))
+        assertTrue(copied.endsWith(CLIPBOARD_REPORT_TRUNCATION_MARKER))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+./gradlew :app:testDebugUnitTest --tests dev.anilbeesetti.nextplayer.crash.CrashLogClipboardTest
+```
+
+Expected: compilation fails because `MAX_CLIPBOARD_REPORT_CHARS`, `CLIPBOARD_REPORT_TRUNCATION_MARKER`, and `crashReportForClipboard` do not exist.
+
+Run:
+
+```bash
+ANDROID_SERIAL=emulator-5554 ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.anilbeesetti.nextplayer.crash.CrashLogClipboardInstrumentedTest
+```
+
+Expected: compilation fails because the clipboard helper symbols do not exist; the test must not pass before implementation.
+
+- [ ] **Step 3: Implement the minimal clipboard bound**
+
+Create `CrashLogClipboard.kt`:
+
+```kotlin
+package dev.anilbeesetti.nextplayer.crash
+
+import android.content.ClipData
+import android.content.ClipboardManager
+
+internal const val MAX_CLIPBOARD_REPORT_CHARS = 100_000
+internal const val CLIPBOARD_REPORT_TRUNCATION_MARKER =
+    "\n\n[Crash report truncated. Use Share for full logs.]"
+
+internal fun crashReportForClipboard(report: String): String {
+    if (report.length <= MAX_CLIPBOARD_REPORT_CHARS) return report
+
+    val prefixLength = MAX_CLIPBOARD_REPORT_CHARS - CLIPBOARD_REPORT_TRUNCATION_MARKER.length
+    return report.take(prefixLength) + CLIPBOARD_REPORT_TRUNCATION_MARKER
+}
+
+internal fun copyCrashReportToClipboard(
+    clipboard: ClipboardManager,
+    report: String,
+) {
+    clipboard.setPrimaryClip(
+        ClipData.newPlainText(null, crashReportForClipboard(report)),
+    )
+}
+```
+
+Replace the direct clipboard call in `CrashActivity` with:
+
+```kotlin
+copyCrashReportToClipboard(
+    clipboard = clipboard.nativeClipboard,
+    report = concatLogs(collectDeviceInfo(), exceptionString, logcat),
+)
+```
+
+Do not change the Share callback or `concatLogs`.
+
+- [ ] **Step 4: Run focused tests to verify GREEN**
+
+Run:
+
+```bash
+./gradlew :app:testDebugUnitTest --tests dev.anilbeesetti.nextplayer.crash.CrashLogClipboardTest
+```
+
+Expected: both JVM tests pass.
+
+Run on the disposable API-36 emulator:
+
+```bash
+ANDROID_SERIAL=emulator-5554 ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.anilbeesetti.nextplayer.crash.CrashLogClipboardInstrumentedTest
+```
+
+Expected: the real clipboard accepts the bounded form of the reported approximately 5.2 MB payload and the instrumentation test passes without `TransactionTooLargeException`.
+
+- [ ] **Step 5: Run regression suites and compile checks**
+
+Run:
+
+```bash
+./gradlew :app:testDebugUnitTest :feature:videopicker:testDebugUnitTest :core:domain:testDebugUnitTest :core:media:testDebugUnitTest :core:model:test :app:assembleDebug
+```
+
+Expected: all tests and the debug build pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/build.gradle.kts app/src/main/java/dev/anilbeesetti/nextplayer/crash/CrashActivity.kt app/src/main/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboard.kt app/src/test/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboardTest.kt app/src/androidTest/java/dev/anilbeesetti/nextplayer/crash/CrashLogClipboardInstrumentedTest.kt docs/superpowers/specs/2026-07-20-issue-1828-crash-log-clipboard-design.md docs/superpowers/plans/2026-07-20-issue-1828-crash-log-clipboard.md
+git commit -m "Fix oversized crash log clipboard copy"
+```

--- a/docs/superpowers/specs/2026-07-20-issue-1828-crash-log-clipboard-design.md
+++ b/docs/superpowers/specs/2026-07-20-issue-1828-crash-log-clipboard-design.md
@@ -1,0 +1,44 @@
+# Issue 1828 Crash-Log Clipboard Design
+
+## Problem
+
+Issue #1828 reports that hiding a large video freezes and crashes the app. The attached exception is a `TransactionTooLargeException` from `ClipboardManager.setPrimaryClip()` with a 5,193,276-byte Binder parcel. The touch-dispatch frames and the repository's only full-report clipboard call show that this is a secondary crash after the user presses Copy on `CrashActivity`, not a vault operation sending video bytes through Binder.
+
+A clean Android 16 (API 36) reproduction hid a synthetic 1 GiB video successfully, with no crash or ANR. Logcat showed Android recovering a failed direct rename by copying across storage boundaries, which can keep the non-dismissible progress UI visible for large physical files, but it did not produce the reported exception. The primary failure that originally opened `CrashActivity` is absent from the issue.
+
+## Approved Scope
+
+Fix the reproducible crash without speculating about an unobserved vault failure:
+
+- Bound only the crash report sent to the system clipboard.
+- Preserve the beginning of the report, which contains device information and the primary exception before logcat.
+- Append a visible truncation marker directing users to Share for complete logs.
+- Keep Share unchanged so it continues writing the full report to a cache file and sending a content URI.
+- Do not change vault move behavior, the Hide UI, or log collection in this fix.
+
+## Design
+
+Add a focused crash-clipboard helper in the app module. It will limit clipboard text to 100,000 UTF-16 characters, including the truncation marker. This is conservatively below Android's 1 MB process-wide Binder transaction buffer: plain text is parcelled as UTF-16, so the bounded payload is approximately 200 KB plus small metadata.
+
+`CrashActivity` will continue composing the full report in its existing order. The Copy action will pass that report through the helper before creating `ClipData`; the Share action will continue using the unbounded report file.
+
+The helper owns two behaviors:
+
+1. Reports at or below the limit are unchanged.
+2. Oversized reports retain their prefix, end with `\n\n[Crash report truncated. Use Share for full logs.]`, and never exceed 100,000 characters.
+
+## Error Handling
+
+The fix prevents the known Binder failure by keeping the transaction well below the documented limit. It does not swallow unrelated clipboard exceptions. If an unrelated platform failure occurs, existing crash handling remains observable rather than silently claiming that Copy succeeded.
+
+## Testing
+
+- JVM tests cover unchanged in-limit reports and exact prefix/marker/length behavior for oversized reports.
+- An API-36 instrumentation regression sends the issue's approximately 5.2 MB UTF-16 payload through the real `ClipboardManager` and verifies that Copy completes and the clipboard contains bounded, marked text.
+- Final emulator QA repeats the 1 GiB Hide journey using UI-tree-derived coordinates and captures a screenshot, logcat, crash buffer, exit info, and ANR state without pressing the unsafe legacy Copy action.
+
+## Non-Goals
+
+- Reworking vault storage or adding transfer progress.
+- Treating file size as Binder data; Hide passes URI and metadata, not video bytes.
+- Truncating the full report written by Share.


### PR DESCRIPTION
## Summary
- cap CrashActivity clipboard reports at 100,000 UTF-16 characters before Binder IPC
- preserve the report prefix and keep file-based Share full and untruncated
- add JVM boundary tests and an API 36 real-clipboard regression test

## Root cause
The TransactionTooLargeException captured in issue #1828 was a secondary crash from copying an unbounded multi-megabyte logcat report through ClipboardManager. Vault move and Hide behavior remain unchanged.

## Testing
- app, video-picker, domain, media, and model unit suites: 28 tests passed
- debug APK assembled successfully
- API 36 instrumentation passed with a 2,596,638-character source report
- 1 GiB video Hide journey passed on a disposable API 36 emulator with no crash or ANR
- task-scoped and whole-branch reviews approved with no remaining findings

Closes #1828