### PR TITLE
Fix vault data loss when hiding videos

### DIFF
--- a/core/data/src/androidTest/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepositoryTest.kt
+++ b/core/data/src/androidTest/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepositoryTest.kt
@@ -1,0 +1,270 @@
+package dev.anilbeesetti.nextplayer.core.data.repository
+
+import android.content.Context
+import android.net.Uri
+import androidx.activity.ComponentActivity
+import androidx.core.net.toUri
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import dev.anilbeesetti.nextplayer.core.database.dao.HiddenVideoDao
+import dev.anilbeesetti.nextplayer.core.database.entities.HiddenVideoEntity
+import dev.anilbeesetti.nextplayer.core.media.services.MediaOperationsService
+import dev.anilbeesetti.nextplayer.core.media.services.TransferEvent
+import dev.anilbeesetti.nextplayer.core.media.services.TransferMode
+import dev.anilbeesetti.nextplayer.core.model.Video
+import java.io.File
+import java.util.UUID
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LocalVaultRepositoryTest {
+
+    @Test
+    fun hideVideosKeepsSourceWhenDatabaseInsertFails() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val fileName = "issue-1828-${UUID.randomUUID()}.mp4"
+        val sourceFile = File(context.cacheDir, fileName).apply { writeText("original video") }
+        val vaultFile = File(File(context.getExternalFilesDir(null), "vault"), fileName)
+        val mediaOperations = MovingMediaOperationsService()
+        val repository = LocalVaultRepository(
+            hiddenVideoDao = FailingInsertHiddenVideoDao,
+            mediaOperationsService = mediaOperations,
+            context = context,
+        )
+
+        try {
+            val result = runCatching {
+                repository.hideVideos(
+                    listOf(
+                        Video.sample.copy(
+                            path = sourceFile.absolutePath,
+                            parentPath = sourceFile.parent.orEmpty(),
+                            uriString = sourceFile.toUri().toString(),
+                            nameWithExtension = fileName,
+                        ),
+                    ),
+                )
+            }
+
+            assertTrue("The repository must handle a rejected vault record", result.isSuccess)
+            assertEquals("The video must not be moved before its vault record exists", 0, mediaOperations.moveCalls)
+            assertTrue("The original video must remain in place", sourceFile.exists())
+            assertFalse("A failed hide must not leave a private vault copy", vaultFile.exists())
+        } finally {
+            sourceFile.delete()
+            vaultFile.delete()
+        }
+    }
+
+    @Test
+    fun hideVideosUsesDistinctVaultFilesForMatchingSourceNames() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val testRoot = File(
+            requireNotNull(context.getExternalFilesDir(null)),
+            "issue-1828-${UUID.randomUUID()}",
+        )
+        val firstSource = File(File(testRoot, "first").apply { mkdirs() }, "duplicate.mp4")
+            .apply { writeText("first video") }
+        val secondSource = File(File(testRoot, "second").apply { mkdirs() }, "duplicate.mp4")
+            .apply { writeText("second video") }
+        val dao = RecordingHiddenVideoDao()
+        val repository = LocalVaultRepository(
+            hiddenVideoDao = dao,
+            mediaOperationsService = MovingMediaOperationsService(),
+            context = context,
+        )
+
+        try {
+            repository.hideVideos(
+                listOf(
+                    videoFor(firstSource),
+                    videoFor(secondSource),
+                ),
+            )
+
+            val vaultFiles = dao.entities.values.map { File(it.vaultPath) }
+            assertEquals(2, vaultFiles.size)
+            assertNotEquals(vaultFiles[0].absolutePath, vaultFiles[1].absolutePath)
+            assertEquals(setOf("first video", "second video"), vaultFiles.map { it.readText() }.toSet())
+            assertFalse(firstSource.exists())
+            assertFalse(secondSource.exists())
+        } finally {
+            dao.entities.values.forEach { File(it.vaultPath).delete() }
+            testRoot.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun hideVideosRemovesReservationAndKeepsSourceWhenMoveFails() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val sourceFile = File(context.cacheDir, "issue-1828-${UUID.randomUUID()}.mp4")
+            .apply { writeText("original video") }
+        val dao = RecordingHiddenVideoDao()
+        val repository = LocalVaultRepository(
+            hiddenVideoDao = dao,
+            mediaOperationsService = MovingMediaOperationsService(moveSucceeds = false),
+            context = context,
+        )
+
+        try {
+            repository.hideVideos(listOf(videoFor(sourceFile)))
+
+            assertTrue("A failed move must preserve the source", sourceFile.exists())
+            assertTrue("A failed move must roll back its reserved row", dao.entities.isEmpty())
+        } finally {
+            sourceFile.delete()
+        }
+    }
+
+    @Test
+    fun hideVideosCleansCommittedReservationWhenInsertIsCancelled() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val sourceFile = File(context.cacheDir, "issue-1828-${UUID.randomUUID()}.mp4")
+            .apply { writeText("original video") }
+        val dao = CommitThenCancelHiddenVideoDao()
+        val mediaOperations = MovingMediaOperationsService()
+        val repository = LocalVaultRepository(dao, mediaOperations, context)
+
+        try {
+            val result = runCatching { repository.hideVideos(listOf(videoFor(sourceFile))) }
+
+            assertTrue(result.exceptionOrNull() is CancellationException)
+            assertTrue("Cancellation before moving must preserve the source", sourceFile.exists())
+            assertTrue("A row committed before cancellation delivery must be cleaned up", dao.entities.isEmpty())
+            assertEquals(0, mediaOperations.moveCalls)
+        } finally {
+            sourceFile.delete()
+        }
+    }
+
+    @Test
+    fun hideVideosCleansReservationAndKeepsSourceWhenMoveIsCancelled() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val sourceFile = File(context.cacheDir, "issue-1828-${UUID.randomUUID()}.mp4")
+            .apply { writeText("original video") }
+        val dao = RecordingHiddenVideoDao()
+        val repository = LocalVaultRepository(
+            hiddenVideoDao = dao,
+            mediaOperationsService = MovingMediaOperationsService(moveException = CancellationException("cancelled")),
+            context = context,
+        )
+
+        try {
+            val result = runCatching { repository.hideVideos(listOf(videoFor(sourceFile))) }
+
+            assertTrue(result.exceptionOrNull() is CancellationException)
+            assertTrue("A cancelled move must preserve the source", sourceFile.exists())
+            assertTrue("A cancelled move must clean up its reservation", dao.entities.isEmpty())
+        } finally {
+            sourceFile.delete()
+        }
+    }
+
+    private fun videoFor(file: File): Video = Video.sample.copy(
+        path = file.absolutePath,
+        parentPath = file.parent.orEmpty(),
+        uriString = file.toUri().toString(),
+        nameWithExtension = file.name,
+    )
+}
+
+private data object FailingInsertHiddenVideoDao : HiddenVideoDao {
+    override suspend fun insert(hiddenVideo: HiddenVideoEntity): Long {
+        error("UNIQUE constraint failed: hidden_video.vault_path")
+    }
+
+    override fun getAll(): Flow<List<HiddenVideoEntity>> = flowOf(emptyList())
+
+    override suspend fun getById(id: Long): HiddenVideoEntity? = null
+
+    override suspend fun deleteByIds(ids: List<Long>) = Unit
+
+    override suspend fun deleteByVaultPaths(vaultPaths: List<String>) = Unit
+}
+
+private class RecordingHiddenVideoDao : HiddenVideoDao {
+    val entities = linkedMapOf<Long, HiddenVideoEntity>()
+    private var nextId = 1L
+
+    override suspend fun insert(hiddenVideo: HiddenVideoEntity): Long {
+        val id = nextId++
+        entities[id] = hiddenVideo.copy(id = id)
+        return id
+    }
+
+    override fun getAll(): Flow<List<HiddenVideoEntity>> = flowOf(entities.values.toList())
+
+    override suspend fun getById(id: Long): HiddenVideoEntity? = entities[id]
+
+    override suspend fun deleteByIds(ids: List<Long>) {
+        ids.forEach(entities::remove)
+    }
+
+    override suspend fun deleteByVaultPaths(vaultPaths: List<String>) {
+        entities.entries.removeAll { it.value.vaultPath in vaultPaths }
+    }
+}
+
+private class CommitThenCancelHiddenVideoDao : HiddenVideoDao {
+    val entities = linkedMapOf<Long, HiddenVideoEntity>()
+
+    override suspend fun insert(hiddenVideo: HiddenVideoEntity): Long {
+        entities[1L] = hiddenVideo.copy(id = 1L)
+        throw CancellationException("cancelled after commit")
+    }
+
+    override fun getAll(): Flow<List<HiddenVideoEntity>> = flowOf(entities.values.toList())
+
+    override suspend fun getById(id: Long): HiddenVideoEntity? = entities[id]
+
+    override suspend fun deleteByIds(ids: List<Long>) {
+        ids.forEach(entities::remove)
+    }
+
+    override suspend fun deleteByVaultPaths(vaultPaths: List<String>) {
+        entities.entries.removeAll { it.value.vaultPath in vaultPaths }
+    }
+}
+
+private class MovingMediaOperationsService(
+    private val moveSucceeds: Boolean = true,
+    private val moveException: Exception? = null,
+) : MediaOperationsService {
+    var moveCalls: Int = 0
+        private set
+
+    override fun initialize(activity: ComponentActivity) = Unit
+
+    override suspend fun deleteMedia(uris: List<Uri>): Boolean = true
+
+    override suspend fun renameMedia(uri: Uri, to: String): Boolean = false
+
+    override suspend fun shareMedia(uris: List<Uri>) = Unit
+
+    override suspend fun moveMedia(targets: Map<Uri, File>): Map<Uri, File?> {
+        moveCalls++
+        moveException?.let { throw it }
+        return targets.mapValues { (uri, destination) ->
+            if (!moveSucceeds) return@mapValues null
+            val source = File(requireNotNull(uri.path))
+            destination.parentFile?.mkdirs()
+            if (source.renameTo(destination)) destination else null
+        }
+    }
+
+    override fun transferMedia(
+        uris: List<Uri>,
+        folderUri: Uri,
+        mode: TransferMode,
+    ): Flow<TransferEvent> = emptyFlow()
+}

--- a/core/data/src/androidTest/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepositoryTest.kt
+++ b/core/data/src/androidTest/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepositoryTest.kt
@@ -15,10 +15,15 @@ import dev.anilbeesetti.nextplayer.core.model.Video
 import java.io.File
 import java.util.UUID
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
@@ -201,12 +206,147 @@ class LocalVaultRepositoryTest {
         }
     }
 
+    @Test
+    fun hideVideosRetainsOnlyCommittedRowsFromPartialMoveResult() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val testRoot = File(
+            requireNotNull(context.getExternalFilesDir(null)),
+            "issue-1828-partial-${UUID.randomUUID()}",
+        )
+        val firstSource = File(File(testRoot, "first").apply { mkdirs() }, "first.mp4")
+            .apply { writeText("first video") }
+        val secondSource = File(File(testRoot, "second").apply { mkdirs() }, "second.mp4")
+            .apply { writeText("second video") }
+        val dao = RecordingHiddenVideoDao()
+        val repository = LocalVaultRepository(
+            hiddenVideoDao = dao,
+            mediaOperationsService = MovingMediaOperationsService(maxSuccessfulMoves = 1),
+            context = context,
+        )
+
+        try {
+            repository.hideVideos(listOf(videoFor(firstSource), videoFor(secondSource)))
+
+            assertEquals(listOf(1L), dao.entities.keys.toList())
+            assertFalse("The first source must be committed", firstSource.exists())
+            assertTrue(
+                "The first reservation must retain its vault file",
+                File(dao.entities.getValue(1L).vaultPath).exists(),
+            )
+            assertTrue("The later uncommitted source must remain", secondSource.exists())
+        } finally {
+            firstSource.delete()
+            secondSource.delete()
+            dao.entities.values.forEach { File(it.vaultPath).delete() }
+            testRoot.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun hideVideosRemovesReservationWhenReportedDestinationIsMissing() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val sourceFile = File(
+            requireNotNull(context.getExternalFilesDir(null)),
+            "issue-1828-missing-destination-${UUID.randomUUID()}.mp4",
+        ).apply { writeText("original video") }
+        val dao = RecordingHiddenVideoDao()
+        val repository = LocalVaultRepository(
+            hiddenVideoDao = dao,
+            mediaOperationsService = MovingMediaOperationsService(deleteDestinationBeforeReturn = true),
+            context = context,
+        )
+
+        try {
+            repository.hideVideos(listOf(videoFor(sourceFile)))
+
+            assertTrue("A missing reported destination must not retain a vault row", dao.entities.isEmpty())
+        } finally {
+            sourceFile.delete()
+            dao.entities.values.forEach { File(it.vaultPath).delete() }
+        }
+    }
+
+    @Test
+    fun observeHiddenVideosDoesNotExposeReservationBeforeMoveCommits() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val sourceFile = File(
+            requireNotNull(context.getExternalFilesDir(null)),
+            "issue-1828-pending-${UUID.randomUUID()}.mp4",
+        ).apply { writeText("original video") }
+        val dao = RecordingHiddenVideoDao()
+        val mediaOperations = PausedMovingMediaOperationsService()
+        val repository = LocalVaultRepository(dao, mediaOperations, context)
+
+        try {
+            val hideJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                repository.hideVideos(listOf(videoFor(sourceFile)))
+            }
+            withTimeout(TEST_TIMEOUT_MILLIS) { mediaOperations.moveStarted.await() }
+
+            assertTrue(
+                "A reservation must stay hidden until its vault file commits",
+                repository.observeHiddenVideos().first().isEmpty(),
+            )
+
+            mediaOperations.allowMove.complete(Unit)
+            withTimeout(TEST_TIMEOUT_MILLIS) { hideJob.join() }
+            assertEquals(1, repository.observeHiddenVideos().first().size)
+        } finally {
+            mediaOperations.allowMove.complete(Unit)
+            sourceFile.delete()
+            dao.entities.values.forEach { File(it.vaultPath).delete() }
+        }
+    }
+
+    @Test
+    fun deleteHiddenVideosWaitsForInProgressHideToCommit() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val sourceFile = File(
+            requireNotNull(context.getExternalFilesDir(null)),
+            "issue-1828-delete-race-${UUID.randomUUID()}.mp4",
+        ).apply { writeText("original video") }
+        val dao = RecordingHiddenVideoDao()
+        val mediaOperations = PausedMovingMediaOperationsService()
+        val repository = LocalVaultRepository(dao, mediaOperations, context)
+
+        try {
+            val hideJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                repository.hideVideos(listOf(videoFor(sourceFile)))
+            }
+            withTimeout(TEST_TIMEOUT_MILLIS) { mediaOperations.moveStarted.await() }
+
+            val deleteJob = launch(start = CoroutineStart.UNDISPATCHED) {
+                repository.deleteHiddenVideos(listOf(videoFor(sourceFile).copy(id = 1L)))
+            }
+
+            assertTrue("Delete must wait for the in-progress hide operation", deleteJob.isActive)
+            assertTrue("Delete must not remove an in-progress reservation", dao.entities.containsKey(1L))
+
+            mediaOperations.allowMove.complete(Unit)
+            withTimeout(TEST_TIMEOUT_MILLIS) {
+                hideJob.join()
+                deleteJob.join()
+            }
+
+            assertFalse(sourceFile.exists())
+            assertTrue(dao.entities.isEmpty())
+        } finally {
+            mediaOperations.allowMove.complete(Unit)
+            sourceFile.delete()
+            dao.entities.values.forEach { File(it.vaultPath).delete() }
+        }
+    }
+
     private fun videoFor(file: File): Video = Video.sample.copy(
         path = file.absolutePath,
         parentPath = file.parent.orEmpty(),
         uriString = file.toUri().toString(),
         nameWithExtension = file.name,
     )
+
+    private companion object {
+        const val TEST_TIMEOUT_MILLIS = 5_000L
+    }
 }
 
 private data object FailingInsertHiddenVideoDao : HiddenVideoDao {
@@ -271,6 +411,8 @@ private class MovingMediaOperationsService(
     private val moveSucceeds: Boolean = true,
     private val moveException: Exception? = null,
     private val moveExceptionAfterCommit: Exception? = null,
+    private val maxSuccessfulMoves: Int = Int.MAX_VALUE,
+    private val deleteDestinationBeforeReturn: Boolean = false,
 ) : MediaOperationsService {
     var moveCalls: Int = 0
         private set
@@ -286,14 +428,46 @@ private class MovingMediaOperationsService(
     override suspend fun moveMedia(targets: Map<Uri, File>): Map<Uri, File?> {
         moveCalls++
         moveException?.let { throw it }
-        val movedFiles = targets.mapValues { (uri, destination) ->
-            if (!moveSucceeds) return@mapValues null
+        val movedFiles = targets.entries.mapIndexed { index, (uri, destination) ->
+            if (!moveSucceeds || index >= maxSuccessfulMoves) return@mapIndexed uri to null
             val source = File(requireNotNull(uri.path))
             destination.parentFile?.mkdirs()
-            if (source.renameTo(destination)) destination else null
+            uri to destination.takeIf { source.renameTo(destination) }
+        }.toMap()
+        if (deleteDestinationBeforeReturn) {
+            movedFiles.values.filterNotNull().forEach(File::delete)
         }
         moveExceptionAfterCommit?.let { throw it }
         return movedFiles
+    }
+
+    override fun transferMedia(
+        uris: List<Uri>,
+        folderUri: Uri,
+        mode: TransferMode,
+    ): Flow<TransferEvent> = emptyFlow()
+}
+
+private class PausedMovingMediaOperationsService : MediaOperationsService {
+    val moveStarted = CompletableDeferred<Unit>()
+    val allowMove = CompletableDeferred<Unit>()
+
+    override fun initialize(activity: ComponentActivity) = Unit
+
+    override suspend fun deleteMedia(uris: List<Uri>): Boolean = true
+
+    override suspend fun renameMedia(uri: Uri, to: String): Boolean = false
+
+    override suspend fun shareMedia(uris: List<Uri>) = Unit
+
+    override suspend fun moveMedia(targets: Map<Uri, File>): Map<Uri, File?> {
+        moveStarted.complete(Unit)
+        allowMove.await()
+        return targets.mapValues { (uri, destination) ->
+            val source = File(requireNotNull(uri.path))
+            destination.parentFile?.mkdirs()
+            destination.takeIf { source.renameTo(destination) }
+        }
     }
 
     override fun transferMedia(

--- a/core/data/src/androidTest/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepositoryTest.kt
+++ b/core/data/src/androidTest/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepositoryTest.kt
@@ -170,6 +170,37 @@ class LocalVaultRepositoryTest {
         }
     }
 
+    @Test
+    fun hideVideosRetainsCommittedReservationWhenMoveIsCancelled() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val sourceFile = File(
+            requireNotNull(context.getExternalFilesDir(null)),
+            "issue-1828-${UUID.randomUUID()}.mp4",
+        )
+            .apply { writeText("original video") }
+        val dao = RecordingHiddenVideoDao()
+        val repository = LocalVaultRepository(
+            hiddenVideoDao = dao,
+            mediaOperationsService = MovingMediaOperationsService(
+                moveExceptionAfterCommit = CancellationException("cancelled"),
+            ),
+            context = context,
+        )
+
+        try {
+            val result = runCatching { repository.hideVideos(listOf(videoFor(sourceFile))) }
+            val vaultFile = File(dao.entities.getValue(1L).vaultPath)
+
+            assertTrue(result.exceptionOrNull() is CancellationException)
+            assertFalse("A committed move must not retain the source", sourceFile.exists())
+            assertTrue("A committed move must retain its reservation", dao.entities.containsKey(1L))
+            assertTrue("A committed move must retain its vault file", vaultFile.exists())
+        } finally {
+            sourceFile.delete()
+            dao.entities.values.forEach { File(it.vaultPath).delete() }
+        }
+    }
+
     private fun videoFor(file: File): Video = Video.sample.copy(
         path = file.absolutePath,
         parentPath = file.parent.orEmpty(),
@@ -239,6 +270,7 @@ private class CommitThenCancelHiddenVideoDao : HiddenVideoDao {
 private class MovingMediaOperationsService(
     private val moveSucceeds: Boolean = true,
     private val moveException: Exception? = null,
+    private val moveExceptionAfterCommit: Exception? = null,
 ) : MediaOperationsService {
     var moveCalls: Int = 0
         private set
@@ -254,12 +286,14 @@ private class MovingMediaOperationsService(
     override suspend fun moveMedia(targets: Map<Uri, File>): Map<Uri, File?> {
         moveCalls++
         moveException?.let { throw it }
-        return targets.mapValues { (uri, destination) ->
+        val movedFiles = targets.mapValues { (uri, destination) ->
             if (!moveSucceeds) return@mapValues null
             val source = File(requireNotNull(uri.path))
             destination.parentFile?.mkdirs()
             if (source.renameTo(destination)) destination else null
         }
+        moveExceptionAfterCommit?.let { throw it }
+        return movedFiles
     }
 
     override fun transferMedia(

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepository.kt
@@ -21,9 +21,12 @@ import dev.anilbeesetti.nextplayer.core.model.MediaInfo
 import dev.anilbeesetti.nextplayer.core.model.Video
 import io.github.anilbeesetti.nextlib.mediainfo.MediaInfoBuilder
 import java.io.File
+import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -46,16 +49,15 @@ class LocalVaultRepository @Inject constructor(
     }
 
     override suspend fun hideVideos(videos: List<Video>) {
-        val movedFiles = mediaOperationsService.moveMedia(
-            uris = videos.map { it.uriString.toUri() },
-            targetDir = vaultDir,
-        )
-
-        videos.forEach { video ->
-            val vaultFile = movedFiles[video.uriString.toUri()] ?: return@forEach
-            hiddenVideoDao.insert(
-                HiddenVideoEntity(
-                    vaultPath = vaultFile.absolutePath,
+        val reservations = mutableListOf<HideReservation>()
+        val attemptedVaultPaths = mutableListOf<String>()
+        try {
+            videos.forEach { video ->
+                val sourceUri = video.uriString.toUri()
+                val destination = createVaultDestination(video.nameWithExtension)
+                attemptedVaultPaths += destination.absolutePath
+                val entity = HiddenVideoEntity(
+                    vaultPath = destination.absolutePath,
                     originalPath = video.path,
                     displayName = video.nameWithExtension,
                     duration = video.duration,
@@ -63,8 +65,70 @@ class LocalVaultRepository @Inject constructor(
                     width = video.width,
                     height = video.height,
                     hiddenAt = System.currentTimeMillis(),
-                ),
+                )
+                val rowId = try {
+                    hiddenVideoDao.insert(entity)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    deleteReservationsByVaultPath(listOf(destination.absolutePath))
+                    return@forEach
+                }
+                reservations += HideReservation(rowId, sourceUri, destination)
+            }
+        } catch (e: CancellationException) {
+            deleteReservationsByVaultPath(attemptedVaultPaths)
+            throw e
+        }
+        if (reservations.isEmpty()) return
+
+        val movedFiles = try {
+            mediaOperationsService.moveMedia(
+                reservations.associate { it.sourceUri to it.destination },
             )
+        } catch (e: CancellationException) {
+            reconcileReservations(reservations, movedFiles = null)
+            throw e
+        } catch (e: Exception) {
+            reconcileReservations(reservations, movedFiles = null)
+            return
+        }
+
+        reconcileReservations(reservations, movedFiles)
+    }
+
+    private data class HideReservation(
+        val rowId: Long,
+        val sourceUri: Uri,
+        val destination: File,
+    )
+
+    private fun createVaultDestination(displayName: String): File {
+        val extension = File(displayName).extension.takeIf { it.isNotBlank() }
+        val suffix = extension?.let { ".$it" }.orEmpty()
+        return generateSequence { File(vaultDir, "${UUID.randomUUID()}$suffix") }
+            .first { !it.exists() }
+    }
+
+    private suspend fun reconcileReservations(
+        reservations: List<HideReservation>,
+        movedFiles: Map<Uri, File?>?,
+    ) {
+        val failedRowIds = reservations.mapNotNull { reservation ->
+            val moveConfirmed = movedFiles?.get(reservation.sourceUri) == reservation.destination
+            val destinationExistsAfterUnknownResult = movedFiles == null && reservation.destination.exists()
+            reservation.rowId.takeUnless { moveConfirmed || destinationExistsAfterUnknownResult }
+        }
+        if (failedRowIds.isEmpty()) return
+        withContext(NonCancellable) {
+            runCatching { hiddenVideoDao.deleteByIds(failedRowIds) }
+        }
+    }
+
+    private suspend fun deleteReservationsByVaultPath(vaultPaths: List<String>) {
+        if (vaultPaths.isEmpty()) return
+        withContext(NonCancellable) {
+            runCatching { hiddenVideoDao.deleteByVaultPaths(vaultPaths) }
         }
     }
 

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepository.kt
@@ -49,52 +49,60 @@ class LocalVaultRepository @Inject constructor(
     }
 
     override suspend fun hideVideos(videos: List<Video>) {
-        val reservations = mutableListOf<HideReservation>()
+        val reservations = reserveVideos(videos)
+        if (reservations.isEmpty()) return
+
+        val moveOutcome = moveReservedVideos(reservations)
+        reconcileReservations(reservations, moveOutcome)
+        moveOutcome.rethrowCancellation()
+    }
+
+    private suspend fun reserveVideos(videos: List<Video>): List<HideReservation> {
         val attemptedVaultPaths = mutableListOf<String>()
-        try {
-            videos.forEach { video ->
-                val sourceUri = video.uriString.toUri()
-                val destination = createVaultDestination(video.nameWithExtension)
-                attemptedVaultPaths += destination.absolutePath
-                val entity = HiddenVideoEntity(
-                    vaultPath = destination.absolutePath,
-                    originalPath = video.path,
-                    displayName = video.nameWithExtension,
-                    duration = video.duration,
-                    size = video.size,
-                    width = video.width,
-                    height = video.height,
-                    hiddenAt = System.currentTimeMillis(),
-                )
-                val rowId = try {
-                    hiddenVideoDao.insert(entity)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    deleteReservationsByVaultPath(listOf(destination.absolutePath))
-                    return@forEach
-                }
-                reservations += HideReservation(rowId, sourceUri, destination)
+        return try {
+            videos.mapNotNull { video ->
+                reserveVideo(video, attemptedVaultPaths)
             }
         } catch (e: CancellationException) {
             deleteReservationsByVaultPath(attemptedVaultPaths)
             throw e
         }
-        if (reservations.isEmpty()) return
+    }
 
-        val movedFiles = try {
-            mediaOperationsService.moveMedia(
-                reservations.associate { it.sourceUri to it.destination },
-            )
+    private suspend fun reserveVideo(
+        video: Video,
+        attemptedVaultPaths: MutableList<String>,
+    ): HideReservation? {
+        val destination = createVaultDestination(video.nameWithExtension)
+        attemptedVaultPaths += destination.absolutePath
+        val sourceUri = video.uriString.toUri()
+        val entity = video.toHiddenVideoEntity(destination)
+        val rowId = try {
+            hiddenVideoDao.insert(entity)
         } catch (e: CancellationException) {
-            reconcileReservations(reservations, movedFiles = null)
             throw e
         } catch (e: Exception) {
-            reconcileReservations(reservations, movedFiles = null)
-            return
+            deleteReservationsByVaultPath(listOf(destination.absolutePath))
+            return null
         }
+        return HideReservation(
+            rowId = rowId,
+            sourceUri = sourceUri,
+            destination = destination,
+        )
+    }
 
-        reconcileReservations(reservations, movedFiles)
+    private fun Video.toHiddenVideoEntity(destination: File): HiddenVideoEntity {
+        return HiddenVideoEntity(
+            vaultPath = destination.absolutePath,
+            originalPath = path,
+            displayName = nameWithExtension,
+            duration = duration,
+            size = size,
+            width = width,
+            height = height,
+            hiddenAt = System.currentTimeMillis(),
+        )
     }
 
     private data class HideReservation(
@@ -102,6 +110,28 @@ class LocalVaultRepository @Inject constructor(
         val sourceUri: Uri,
         val destination: File,
     )
+
+    private sealed interface MoveOutcome {
+        data class Completed(val movedFiles: Map<Uri, File?>) : MoveOutcome
+        data object Failed : MoveOutcome
+        data class Cancelled(val exception: CancellationException) : MoveOutcome
+    }
+
+    private suspend fun moveReservedVideos(
+        reservations: List<HideReservation>,
+    ): MoveOutcome {
+        return try {
+            MoveOutcome.Completed(
+                mediaOperationsService.moveMedia(
+                    reservations.associate { it.sourceUri to it.destination },
+                ),
+            )
+        } catch (e: CancellationException) {
+            MoveOutcome.Cancelled(e)
+        } catch (e: Exception) {
+            MoveOutcome.Failed
+        }
+    }
 
     private fun createVaultDestination(displayName: String): File {
         val extension = File(displayName).extension.takeIf { it.isNotBlank() }
@@ -112,17 +142,28 @@ class LocalVaultRepository @Inject constructor(
 
     private suspend fun reconcileReservations(
         reservations: List<HideReservation>,
-        movedFiles: Map<Uri, File?>?,
+        moveOutcome: MoveOutcome,
     ) {
         val failedRowIds = reservations.mapNotNull { reservation ->
-            val moveConfirmed = movedFiles?.get(reservation.sourceUri) == reservation.destination
-            val destinationExistsAfterUnknownResult = movedFiles == null && reservation.destination.exists()
-            reservation.rowId.takeUnless { moveConfirmed || destinationExistsAfterUnknownResult }
+            reservation.rowId.takeUnless { moveOutcome.wasCommitted(reservation) }
         }
         if (failedRowIds.isEmpty()) return
         withContext(NonCancellable) {
             runCatching { hiddenVideoDao.deleteByIds(failedRowIds) }
         }
+    }
+
+    private fun MoveOutcome.wasCommitted(reservation: HideReservation): Boolean {
+        return when (this) {
+            is MoveOutcome.Completed -> {
+                movedFiles[reservation.sourceUri] == reservation.destination
+            }
+            MoveOutcome.Failed, is MoveOutcome.Cancelled -> reservation.destination.exists()
+        }
+    }
+
+    private fun MoveOutcome.rethrowCancellation() {
+        if (this is MoveOutcome.Cancelled) throw exception
     }
 
     private suspend fun deleteReservationsByVaultPath(vaultPaths: List<String>) {

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepository.kt
@@ -10,6 +10,7 @@ import android.webkit.MimeTypeMap
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.anilbeesetti.nextplayer.core.common.Logger
 import dev.anilbeesetti.nextplayer.core.common.Utils
 import dev.anilbeesetti.nextplayer.core.data.mappers.toAudioStreamInfo
 import dev.anilbeesetti.nextplayer.core.data.mappers.toSubtitleStreamInfo
@@ -28,8 +29,12 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 @Singleton
@@ -39,22 +44,38 @@ class LocalVaultRepository @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : VaultRepository {
 
+    private val vaultMutationMutex = Mutex()
+    private val pendingVaultPaths = MutableStateFlow<Set<String>>(emptySet())
+
     private val vaultDir: File by lazy {
         val base = context.getExternalFilesDir(null) ?: context.filesDir
         File(base, VAULT_DIR_NAME).apply { if (!exists()) mkdirs() }
     }
 
     override fun observeHiddenVideos(): Flow<List<Video>> {
-        return hiddenVideoDao.getAll().map { entities -> entities.map { it.toVideo() } }
+        return combine(hiddenVideoDao.getAll(), pendingVaultPaths) { entities, pendingPaths ->
+            entities
+                .filterNot { it.vaultPath in pendingPaths }
+                .filter { File(it.vaultPath).exists() }
+                .map { it.toVideo() }
+        }
     }
 
-    override suspend fun hideVideos(videos: List<Video>) {
+    override suspend fun hideVideos(videos: List<Video>) = vaultMutationMutex.withLock {
+        hideVideosLocked(videos)
+    }
+
+    private suspend fun hideVideosLocked(videos: List<Video>) {
         val reservations = reserveVideos(videos)
         if (reservations.isEmpty()) return
 
-        val moveOutcome = moveReservedVideos(reservations)
-        reconcileReservations(reservations, moveOutcome)
-        moveOutcome.rethrowCancellation()
+        try {
+            val moveOutcome = moveReservedVideos(reservations)
+            reconcileReservations(reservations, moveOutcome)
+            moveOutcome.rethrowCancellation()
+        } finally {
+            revealReservations(reservations.map { it.destination.absolutePath })
+        }
     }
 
     private suspend fun reserveVideos(videos: List<Video>): List<HideReservation> {
@@ -65,6 +86,7 @@ class LocalVaultRepository @Inject constructor(
             }
         } catch (e: CancellationException) {
             deleteReservationsByVaultPath(attemptedVaultPaths)
+            revealReservations(attemptedVaultPaths)
             throw e
         }
     }
@@ -77,12 +99,14 @@ class LocalVaultRepository @Inject constructor(
         attemptedVaultPaths += destination.absolutePath
         val sourceUri = video.uriString.toUri()
         val entity = video.toHiddenVideoEntity(destination)
+        pendingVaultPaths.update { it + destination.absolutePath }
         val rowId = try {
             hiddenVideoDao.insert(entity)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             deleteReservationsByVaultPath(listOf(destination.absolutePath))
+            revealReservations(listOf(destination.absolutePath))
             return null
         }
         return HideReservation(
@@ -150,13 +174,15 @@ class LocalVaultRepository @Inject constructor(
         if (failedRowIds.isEmpty()) return
         withContext(NonCancellable) {
             runCatching { hiddenVideoDao.deleteByIds(failedRowIds) }
+                .onFailure { logCleanupFailure("delete failed hide reservations", it) }
         }
     }
 
     private fun MoveOutcome.wasCommitted(reservation: HideReservation): Boolean {
         return when (this) {
             is MoveOutcome.Completed -> {
-                movedFiles[reservation.sourceUri] == reservation.destination
+                movedFiles[reservation.sourceUri] == reservation.destination &&
+                    reservation.destination.exists()
             }
             MoveOutcome.Failed, is MoveOutcome.Cancelled -> reservation.destination.exists()
         }
@@ -170,17 +196,26 @@ class LocalVaultRepository @Inject constructor(
         if (vaultPaths.isEmpty()) return
         withContext(NonCancellable) {
             runCatching { hiddenVideoDao.deleteByVaultPaths(vaultPaths) }
+                .onFailure { logCleanupFailure("delete reservations by vault path", it) }
         }
     }
 
-    override suspend fun unhideVideos(videos: List<Video>): UnhideResult {
+    private fun revealReservations(vaultPaths: List<String>) {
+        pendingVaultPaths.update { it - vaultPaths.toSet() }
+    }
+
+    private fun logCleanupFailure(operation: String, throwable: Throwable) {
+        Logger.logError(TAG, "Failed to $operation: ${throwable.stackTraceToString()}")
+    }
+
+    override suspend fun unhideVideos(videos: List<Video>): UnhideResult = vaultMutationMutex.withLock {
         val restored = withContext(Dispatchers.IO) {
             entitiesFor(videos).mapNotNull { entity ->
                 restoreToMediaStore(entity)?.let { relocated -> entity.id to relocated }
             }
         }
         if (restored.isNotEmpty()) hiddenVideoDao.deleteByIds(restored.map { it.first })
-        return UnhideResult(relocatedCount = restored.count { (_, relocated) -> relocated })
+        UnhideResult(relocatedCount = restored.count { (_, relocated) -> relocated })
     }
 
     /**
@@ -272,9 +307,9 @@ class LocalVaultRepository @Inject constructor(
         return parent.removePrefix(root).trim('/').takeIf { it.isNotEmpty() }?.let { "$it/" }
     }
 
-    override suspend fun deleteHiddenVideos(videos: List<Video>) {
+    override suspend fun deleteHiddenVideos(videos: List<Video>): Unit = vaultMutationMutex.withLock {
         val entities = entitiesFor(videos)
-        if (entities.isEmpty()) return
+        if (entities.isEmpty()) return@withLock
         entities.forEach { File(it.vaultPath).delete() }
         hiddenVideoDao.deleteByIds(entities.map { it.id })
     }
@@ -322,6 +357,7 @@ class LocalVaultRepository @Inject constructor(
     }
 
     companion object {
+        private const val TAG = "LocalVaultRepository"
         private const val VAULT_DIR_NAME = "vault"
 
         /** Fallback folder for videos whose original location MediaStore won't accept. */

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepository.kt
@@ -84,9 +84,8 @@ class LocalVaultRepository @Inject constructor(
             videos.mapNotNull { video ->
                 reserveVideo(video, attemptedVaultPaths)
             }
-        } catch (e: CancellationException) {
-            deleteReservationsByVaultPath(attemptedVaultPaths)
-            revealReservations(attemptedVaultPaths)
+        } catch (e: Exception) {
+            cleanUpReservations(attemptedVaultPaths)
             throw e
         }
     }
@@ -105,8 +104,7 @@ class LocalVaultRepository @Inject constructor(
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            deleteReservationsByVaultPath(listOf(destination.absolutePath))
-            revealReservations(listOf(destination.absolutePath))
+            cleanUpReservations(listOf(destination.absolutePath))
             return null
         }
         return HideReservation(
@@ -198,6 +196,11 @@ class LocalVaultRepository @Inject constructor(
             runCatching { hiddenVideoDao.deleteByVaultPaths(vaultPaths) }
                 .onFailure { logCleanupFailure("delete reservations by vault path", it) }
         }
+    }
+
+    private suspend fun cleanUpReservations(vaultPaths: List<String>) {
+        deleteReservationsByVaultPath(vaultPaths)
+        revealReservations(vaultPaths)
     }
 
     private fun revealReservations(vaultPaths: List<String>) {

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/dao/HiddenVideoDao.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/dao/HiddenVideoDao.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 interface HiddenVideoDao {
 
     @Insert
-    suspend fun insert(hiddenVideo: HiddenVideoEntity)
+    suspend fun insert(hiddenVideo: HiddenVideoEntity): Long
 
     @Query("SELECT * FROM hidden_video ORDER BY hidden_at DESC")
     fun getAll(): Flow<List<HiddenVideoEntity>>
@@ -20,4 +20,7 @@ interface HiddenVideoDao {
 
     @Query("DELETE FROM hidden_video WHERE id IN (:ids)")
     suspend fun deleteByIds(ids: List<Long>)
+
+    @Query("DELETE FROM hidden_video WHERE vault_path IN (:vaultPaths)")
+    suspend fun deleteByVaultPaths(vaultPaths: List<String>)
 }

--- a/core/media/src/androidTest/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsServiceTest.kt
+++ b/core/media/src/androidTest/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsServiceTest.kt
@@ -1,0 +1,138 @@
+package dev.anilbeesetti.nextplayer.core.media.services
+
+import android.content.Context
+import androidx.core.net.toUri
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.io.File
+import java.util.UUID
+import java.util.concurrent.CyclicBarrier
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LocalMediaOperationsServiceTest {
+
+    @Test
+    fun moveMediaDoesNotOverwriteAnExistingVaultFile() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val testRoot = File(context.cacheDir, "issue-1828-${UUID.randomUUID()}")
+        val sourceDir = File(testRoot, "source").apply { mkdirs() }
+        val targetDir = File(testRoot, "vault").apply { mkdirs() }
+        val sourceFile = File(sourceDir, "duplicate.mp4").apply { writeText("new source") }
+        val existingVaultFile = File(targetDir, sourceFile.name).apply { writeText("existing vault video") }
+        val sourceUri = sourceFile.toUri()
+
+        try {
+            val moved = LocalMediaOperationsService(context).moveMedia(mapOf(sourceUri to existingVaultFile))
+
+            assertNull("A colliding source must be reported as not moved", moved[sourceUri])
+            assertTrue("The colliding source must remain in its original location", sourceFile.exists())
+            assertEquals("existing vault video", existingVaultFile.readText())
+        } finally {
+            testRoot.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun concurrentMovesToOneDestinationPreserveTheLosingSource() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val testRoot = File(context.cacheDir, "issue-1828-race-${UUID.randomUUID()}")
+        val sourceFiles = listOf("first video", "second video").mapIndexed { index, content ->
+            File(File(testRoot, "source-$index").apply { mkdirs() }, "duplicate.mp4")
+                .apply { writeText(content) }
+        }
+        val destination = File(File(testRoot, "vault").apply { mkdirs() }, "shared.mp4")
+        val barrier = CyclicBarrier(sourceFiles.size)
+        val service = LocalMediaOperationsService(context)
+
+        try {
+            val results = coroutineScope {
+                sourceFiles.map { source ->
+                    async(Dispatchers.Default) {
+                        barrier.await()
+                        val uri = source.toUri()
+                        service.moveMedia(mapOf(uri to destination))[uri]
+                    }
+                }.awaitAll()
+            }
+
+            assertEquals(1, results.count { it != null })
+            assertEquals("Exactly one losing source must remain", 1, sourceFiles.count { it.exists() })
+            assertTrue(destination.readText() in setOf("first video", "second video"))
+        } finally {
+            testRoot.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun cancellationDuringCopyPreservesSourceAndRemovesPartialDestination() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val testRoot = File(context.cacheDir, "issue-1828-cancel-${UUID.randomUUID()}")
+        val source = File(File(testRoot, "source").apply { mkdirs() }, "large.mp4")
+            .apply { writeBytes(ByteArray(DEFAULT_BUFFER_SIZE * 4) { it.toByte() }) }
+        val destination = File(File(testRoot, "vault").apply { mkdirs() }, "unique.mp4")
+        var cancellationChecks = 0
+
+        try {
+            assertThrows(CancellationException::class.java) {
+                LocalMediaOperationsService(context).moveFileWithoutOverwrite(source, destination) {
+                    cancellationChecks += 1
+                    if (cancellationChecks == 2) throw CancellationException("cancel during copy")
+                }
+            }
+
+            assertTrue("Cancellation must leave the source video untouched", source.exists())
+            assertEquals(DEFAULT_BUFFER_SIZE * 4L, source.length())
+            assertTrue("A partial vault copy must be removed", !destination.exists())
+        } finally {
+            testRoot.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun cancellationAfterCommittedMovePreservesRemainingSource() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val testRoot = File(context.cacheDir, "issue-1828-batch-cancel-${UUID.randomUUID()}")
+        val firstSource = File(File(testRoot, "source-1").apply { mkdirs() }, "first.mp4")
+            .apply { writeText("first video") }
+        val secondSource = File(File(testRoot, "source-2").apply { mkdirs() }, "second.mp4")
+            .apply { writeBytes(ByteArray(64 * 1024 * 1024)) }
+        val vaultDir = File(testRoot, "vault").apply { mkdirs() }
+        val firstDestination = File(vaultDir, "first.mp4")
+        val secondDestination = File(vaultDir, "second.mp4")
+        val service = LocalMediaOperationsService(context)
+
+        try {
+            val moveJob = launch(Dispatchers.Default) {
+                service.moveMedia(
+                    linkedMapOf(
+                        firstSource.toUri() to firstDestination,
+                        secondSource.toUri() to secondDestination,
+                    ),
+                )
+            }
+            while (firstSource.exists()) yield()
+            moveJob.cancelAndJoin()
+
+            assertTrue("The committed first vault copy must remain", firstDestination.exists())
+            assertTrue("The uncommitted second source must remain", secondSource.exists())
+            assertTrue("A cancelled second vault copy must be removed", !secondDestination.exists())
+        } finally {
+            testRoot.deleteRecursively()
+        }
+    }
+}

--- a/core/media/src/androidTest/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsServiceTest.kt
+++ b/core/media/src/androidTest/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsServiceTest.kt
@@ -8,6 +8,7 @@ import java.io.File
 import java.util.UUID
 import java.util.concurrent.CyclicBarrier
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -15,7 +16,7 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.yield
+import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
@@ -110,11 +111,13 @@ class LocalMediaOperationsServiceTest {
         val firstSource = File(File(testRoot, "source-1").apply { mkdirs() }, "first.mp4")
             .apply { writeText("first video") }
         val secondSource = File(File(testRoot, "source-2").apply { mkdirs() }, "second.mp4")
-            .apply { writeBytes(ByteArray(64 * 1024 * 1024)) }
+            .apply { writeText("second video") }
         val vaultDir = File(testRoot, "vault").apply { mkdirs() }
         val firstDestination = File(vaultDir, "first.mp4")
         val secondDestination = File(vaultDir, "second.mp4")
         val service = LocalMediaOperationsService(context)
+        val firstMoveCommitted = CompletableDeferred<Unit>()
+        val allowSecondMove = CompletableDeferred<Unit>()
 
         try {
             val moveJob = launch(Dispatchers.Default) {
@@ -123,10 +126,15 @@ class LocalMediaOperationsServiceTest {
                         firstSource.toUri() to firstDestination,
                         secondSource.toUri() to secondDestination,
                     ),
-                )
+                ) {
+                    firstMoveCommitted.complete(Unit)
+                    allowSecondMove.await()
+                }
             }
-            while (firstSource.exists()) yield()
-            moveJob.cancelAndJoin()
+            withTimeout(TEST_TIMEOUT_MILLIS) { firstMoveCommitted.await() }
+            moveJob.cancel()
+            allowSecondMove.complete(Unit)
+            withTimeout(TEST_TIMEOUT_MILLIS) { moveJob.cancelAndJoin() }
 
             assertTrue("The committed first vault copy must remain", firstDestination.exists())
             assertTrue("The uncommitted second source must remain", secondSource.exists())
@@ -134,5 +142,9 @@ class LocalMediaOperationsServiceTest {
         } finally {
             testRoot.deleteRecursively()
         }
+    }
+
+    private companion object {
+        const val TEST_TIMEOUT_MILLIS = 5_000L
     }
 }

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsService.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsService.kt
@@ -22,6 +22,7 @@ import dev.anilbeesetti.nextplayer.core.common.extensions.getPath
 import dev.anilbeesetti.nextplayer.core.common.extensions.scanPaths
 import dev.anilbeesetti.nextplayer.core.common.extensions.updateMedia
 import java.io.File
+import java.io.FileOutputStream
 import java.io.InputStream
 import java.io.OutputStream
 import javax.inject.Inject
@@ -30,7 +31,11 @@ import kotlin.coroutines.resume
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
@@ -89,20 +94,95 @@ class LocalMediaOperationsService @Inject constructor(
         activity.startActivity(intent)
     }
 
-    override suspend fun moveMedia(uris: List<Uri>, targetDir: File): Map<Uri, File?> = withContext(Dispatchers.IO) {
+    override suspend fun moveMedia(targets: Map<Uri, File>): Map<Uri, File?> {
+        val uris = targets.keys.toList()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val mediaStoreUris = uris.filter { it.authority == MediaStore.AUTHORITY }
             if (mediaStoreUris.isNotEmpty()) {
-                val granted = requestWriteAccessR(mediaStoreUris)
-                if (!granted) return@withContext uris.associateWith { null }
+                val granted = try {
+                    requestWriteAccessR(mediaStoreUris)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    false
+                }
+                if (!granted) return targets.keys.associateWith { null }
             }
         }
 
-        uris.associateWith { uri ->
-            val sourceFile = context.getPath(uri)?.let { File(it) } ?: return@associateWith null
-            val destFile = File(targetDir, sourceFile.name)
-            if (sourceFile.renameTo(destFile)) destFile else null
+        val callerJob = currentCoroutineContext()[Job]
+        return withContext(NonCancellable) {
+            withContext(Dispatchers.IO) io@{
+                val movedFiles = linkedMapOf<Uri, File?>()
+                val entries = targets.entries.iterator()
+                var moveCommitted = false
+                while (entries.hasNext()) {
+                    val (uri, destination) = entries.next()
+                    val movedFile = try {
+                        callerJob?.ensureActive()
+                        val sourceFile = context.getPath(uri)?.let { File(it) }
+                        if (sourceFile == null) {
+                            null
+                        } else {
+                            destination.parentFile?.mkdirs()
+                            moveFileWithoutOverwrite(sourceFile, destination) { callerJob?.ensureActive() }
+                        }
+                    } catch (e: CancellationException) {
+                        if (!moveCommitted) throw e
+                        movedFiles[uri] = null
+                        while (entries.hasNext()) movedFiles[entries.next().key] = null
+                        return@io movedFiles
+                    } catch (e: Exception) {
+                        null
+                    }
+                    movedFiles[uri] = movedFile
+                    moveCommitted = moveCommitted || movedFile != null
+                }
+                movedFiles
+            }
         }
+    }
+
+    /** Copies into an exclusively-created destination before atomically committing source deletion. */
+    internal fun moveFileWithoutOverwrite(
+        source: File,
+        destination: File,
+        ensureActive: () -> Unit,
+    ): File? {
+        if (!source.exists() || !destination.createNewFile()) return null
+        val expectedBytes = source.length()
+
+        val copiedBytes = try {
+            source.inputStream().use { input ->
+                FileOutputStream(destination).use { output ->
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                    var copied = 0L
+                    while (true) {
+                        ensureActive()
+                        val read = input.read(buffer)
+                        if (read < 0) break
+                        output.write(buffer, 0, read)
+                        copied += read
+                    }
+                    output.fd.sync()
+                    ensureActive()
+                    copied
+                }
+            }
+        } catch (e: CancellationException) {
+            destination.delete()
+            throw e
+        } catch (e: Exception) {
+            destination.delete()
+            return null
+        }
+
+        // Cancellation before this point rolls back the destination. From here, the move is committed.
+        if (copiedBytes != expectedBytes || !source.delete()) {
+            destination.delete()
+            return null
+        }
+        return destination
     }
 
     override fun transferMedia(

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsService.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsService.kt
@@ -95,6 +95,17 @@ class LocalMediaOperationsService @Inject constructor(
     }
 
     override suspend fun moveMedia(targets: Map<Uri, File>): Map<Uri, File?> {
+        return moveMedia(targets, onMoveCommitted = null)
+    }
+
+    /**
+     * The internal callback is a deterministic synchronization seam for commit-boundary tests.
+     * Production calls use [moveMedia] and pay no callback cost.
+     */
+    internal suspend fun moveMedia(
+        targets: Map<Uri, File>,
+        onMoveCommitted: (suspend (Uri) -> Unit)?,
+    ): Map<Uri, File?> {
         val uris = targets.keys.toList()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             val mediaStoreUris = uris.filter { it.authority == MediaStore.AUTHORITY }
@@ -137,6 +148,7 @@ class LocalMediaOperationsService @Inject constructor(
                     }
                     movedFiles[uri] = movedFile
                     moveCommitted = moveCommitted || movedFile != null
+                    if (movedFile != null) onMoveCommitted?.invoke(uri)
                 }
                 movedFiles
             }

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaOperationsService.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaOperationsService.kt
@@ -12,7 +12,7 @@ interface MediaOperationsService {
     suspend fun deleteMedia(uris: List<Uri>): Boolean
     suspend fun renameMedia(uri: Uri, to: String): Boolean
     suspend fun shareMedia(uris: List<Uri>)
-    suspend fun moveMedia(uris: List<Uri>, targetDir: File): Map<Uri, File?>
+    suspend fun moveMedia(targets: Map<Uri, File>): Map<Uri, File?>
 
     fun transferMedia(
         uris: List<Uri>,

--- a/docs/superpowers/plans/2026-07-24-local-vault-repository-readability.md
+++ b/docs/superpowers/plans/2026-07-24-local-vault-repository-readability.md
@@ -1,0 +1,247 @@
+# LocalVaultRepository Readability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `LocalVaultRepository.hideVideos` into explicit reservation, movement, and reconciliation phases without changing vault safety behavior. Add deterministic coverage for a move that commits before cancellation is delivered.
+
+**Architecture:** Keep the entire workflow private to `LocalVaultRepository`. The public override becomes a short orchestrator, while private helpers own reservation creation, entity mapping, batched movement, and outcome reconciliation. A private sealed `MoveOutcome` replaces the nullable move-map control flow at the orchestration boundary.
+
+**Tech Stack:** Kotlin, coroutines, Room DAO, Android instrumentation tests, Gradle
+
+## Global Constraints
+
+- Keep every implementation detail private to `LocalVaultRepository`.
+- Preserve the existing single batched media permission request.
+- Preserve source files whenever their corresponding hide operation does not commit.
+- Make no database schema or DAO changes.
+- Make no changes to `MediaOperationsService`.
+- Add no injected classes or public abstractions.
+- Make no changes to vault restore behavior or user-visible behavior.
+
+---
+
+### Task 1: Refactor the hide workflow into named phases
+
+**Files:**
+- Modify: `core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepository.kt:51-129`
+- Test: `core/data/src/androidTest/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepositoryTest.kt`
+
+**Interfaces:**
+- Consumes: `HiddenVideoDao.insert(HiddenVideoEntity): Long`, `HiddenVideoDao.deleteByIds(List<Long>)`, `HiddenVideoDao.deleteByVaultPaths(List<String>)`, and `MediaOperationsService.moveMedia(Map<Uri, File>): Map<Uri, File?>`
+- Produces: private `reserveVideos`, `reserveVideo`, `moveReservedVideos`, `MoveOutcome`, `MoveOutcome.wasCommitted`, and `MoveOutcome.rethrowCancellation`
+
+- [ ] **Step 1: Establish the characterization-test baseline**
+
+Run the existing repository instrumentation tests before editing production code:
+
+```bash
+ANDROID_SERIAL=emulator-5582 \
+ANDROID_HOME=/Users/anil/Library/Android/sdk \
+ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk \
+./gradlew :core:data:connectedDebugAndroidTest --console=plain
+```
+
+Expected: all 5 existing `LocalVaultRepositoryTest` tests pass.
+
+- [ ] **Step 2: Replace `hideVideos` with phase-oriented orchestration**
+
+Replace the current `hideVideos` body with:
+
+```kotlin
+override suspend fun hideVideos(videos: List<Video>) {
+    val reservations = reserveVideos(videos)
+    if (reservations.isEmpty()) return
+
+    val moveOutcome = moveReservedVideos(reservations)
+    reconcileReservations(reservations, moveOutcome)
+    moveOutcome.rethrowCancellation()
+}
+```
+
+This method must contain no DAO insertion loop, filesystem result inspection, or
+exception-handling branches.
+
+- [ ] **Step 3: Extract reservation creation and entity mapping**
+
+Add these private helpers immediately after `hideVideos`:
+
+```kotlin
+private suspend fun reserveVideos(videos: List<Video>): List<HideReservation> {
+    val attemptedVaultPaths = mutableListOf<String>()
+    return try {
+        videos.mapNotNull { video ->
+            reserveVideo(video, attemptedVaultPaths)
+        }
+    } catch (e: CancellationException) {
+        deleteReservationsByVaultPath(attemptedVaultPaths)
+        throw e
+    }
+}
+
+private suspend fun reserveVideo(
+    video: Video,
+    attemptedVaultPaths: MutableList<String>,
+): HideReservation? {
+    val destination = createVaultDestination(video.nameWithExtension)
+    attemptedVaultPaths += destination.absolutePath
+    val sourceUri = video.uriString.toUri()
+    val entity = video.toHiddenVideoEntity(destination)
+    val rowId = try {
+        hiddenVideoDao.insert(entity)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        deleteReservationsByVaultPath(listOf(destination.absolutePath))
+        return null
+    }
+    return HideReservation(
+        rowId = rowId,
+        sourceUri = sourceUri,
+        destination = destination,
+    )
+}
+
+private fun Video.toHiddenVideoEntity(destination: File): HiddenVideoEntity {
+    return HiddenVideoEntity(
+        vaultPath = destination.absolutePath,
+        originalPath = path,
+        displayName = nameWithExtension,
+        duration = duration,
+        size = size,
+        width = width,
+        height = height,
+        hiddenAt = System.currentTimeMillis(),
+    )
+}
+```
+
+Keep `HideReservation` private and retain its existing fields.
+
+- [ ] **Step 4: Introduce an explicit move outcome**
+
+Add the private sealed outcome beside `HideReservation`:
+
+```kotlin
+private sealed interface MoveOutcome {
+    data class Completed(val movedFiles: Map<Uri, File?>) : MoveOutcome
+    data object Failed : MoveOutcome
+    data class Cancelled(val exception: CancellationException) : MoveOutcome
+}
+```
+
+Add the batched move helper:
+
+```kotlin
+private suspend fun moveReservedVideos(
+    reservations: List<HideReservation>,
+): MoveOutcome {
+    return try {
+        MoveOutcome.Completed(
+            mediaOperationsService.moveMedia(
+                reservations.associate { it.sourceUri to it.destination },
+            ),
+        )
+    } catch (e: CancellationException) {
+        MoveOutcome.Cancelled(e)
+    } catch (e: Exception) {
+        MoveOutcome.Failed
+    }
+}
+```
+
+This must invoke `moveMedia` once so Android 11+ still presents one batched permission
+request.
+
+- [ ] **Step 5: Make reconciliation outcome-driven**
+
+Change `reconcileReservations` to accept `MoveOutcome`:
+
+```kotlin
+private suspend fun reconcileReservations(
+    reservations: List<HideReservation>,
+    moveOutcome: MoveOutcome,
+) {
+    val failedRowIds = reservations.mapNotNull { reservation ->
+        reservation.rowId.takeUnless { moveOutcome.wasCommitted(reservation) }
+    }
+    if (failedRowIds.isEmpty()) return
+    withContext(NonCancellable) {
+        runCatching { hiddenVideoDao.deleteByIds(failedRowIds) }
+    }
+}
+```
+
+Add the outcome helpers:
+
+```kotlin
+private fun MoveOutcome.wasCommitted(reservation: HideReservation): Boolean {
+    return when (this) {
+        is MoveOutcome.Completed -> {
+            movedFiles[reservation.sourceUri] == reservation.destination
+        }
+        MoveOutcome.Failed, is MoveOutcome.Cancelled -> reservation.destination.exists()
+    }
+}
+
+private fun MoveOutcome.rethrowCancellation() {
+    if (this is MoveOutcome.Cancelled) throw exception
+}
+```
+
+For an unknown partial result, destination existence remains the evidence that the
+media service committed the move before throwing.
+
+- [ ] **Step 6: Run focused compilation and formatting checks**
+
+```bash
+ANDROID_HOME=/Users/anil/Library/Android/sdk \
+ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk \
+./gradlew \
+  :core:data:compileDebugKotlin \
+  :core:data:compileDebugAndroidTestKotlin \
+  :core:data:ktlintCheck \
+  --console=plain
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 7: Run the repository behavior tests after the refactor**
+
+```bash
+ANDROID_SERIAL=emulator-5582 \
+ANDROID_HOME=/Users/anil/Library/Android/sdk \
+ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk \
+./gradlew :core:data:connectedDebugAndroidTest --console=plain
+```
+
+Expected: all 6 `LocalVaultRepositoryTest` tests pass, including cancellation after a committed move.
+
+- [ ] **Step 8: Run the complete PR verification**
+
+```bash
+ANDROID_SERIAL=emulator-5582 \
+ANDROID_HOME=/Users/anil/Library/Android/sdk \
+ANDROID_SDK_ROOT=/Users/anil/Library/Android/sdk \
+./gradlew \
+  :core:data:connectedDebugAndroidTest \
+  :core:media:connectedDebugAndroidTest \
+  ktlintCheck \
+  testDebugUnitTest \
+  :app:assembleDebug \
+  --console=plain
+```
+
+Expected: 6 data tests, 5 media tests, all debug unit tests, formatting checks, and
+debug APK assembly pass.
+
+- [ ] **Step 9: Commit and update the PR branch**
+
+```bash
+git add \
+  core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepository.kt \
+  docs/superpowers/plans/2026-07-24-local-vault-repository-readability.md
+git commit -m "Refactor vault hide workflow for readability"
+git push origin codex/fix-issue-1828-vault-data-loss
+```
+
+Expected: the commit is added to pull request 1834 and the worktree is clean.

--- a/docs/superpowers/specs/2026-07-24-local-vault-repository-readability-design.md
+++ b/docs/superpowers/specs/2026-07-24-local-vault-repository-readability-design.md
@@ -1,0 +1,106 @@
+# LocalVaultRepository Hide Workflow Readability
+
+## Context
+
+The issue 1828 fix made hiding videos failure-safe, but `LocalVaultRepository.hideVideos`
+now interleaves four responsibilities:
+
+1. Creating unique vault destinations.
+2. Reserving database rows.
+3. Moving the source files.
+4. Reconciling database rows after success, failure, or cancellation.
+
+The behavior is covered by repository and media-operation instrumentation tests. This
+refactor must improve readability without changing those guarantees.
+
+## Goals
+
+- Make `hideVideos` read as a short sequence of named workflow phases.
+- Keep every implementation detail private to `LocalVaultRepository`.
+- Make move completion, failure, and cancellation explicit rather than representing
+  all unknown results with a nullable map at the orchestration level.
+- Preserve the existing single batched media permission request.
+- Preserve source files whenever their corresponding hide operation does not commit.
+
+## Non-goals
+
+- No database schema or DAO changes.
+- No changes to `MediaOperationsService`.
+- No new injected classes or public abstractions.
+- No changes to vault restore behavior.
+- No changes to user-visible behavior.
+
+## Design
+
+### Public orchestration
+
+`hideVideos` will contain only the workflow:
+
+1. Reserve the requested videos.
+2. Return when no reservation succeeded.
+3. Move all reserved videos in one batch.
+4. Reconcile reservations from the explicit move outcome.
+5. Rethrow cancellation only after reconciliation.
+
+This keeps the safety ordering visible without exposing implementation details.
+
+### Reservation phase
+
+`reserveVideos` will own the reservation loop and cancellation cleanup.
+`reserveVideo` will:
+
+- create a UUID-backed destination,
+- create the `HiddenVideoEntity`,
+- insert the row,
+- return a `HideReservation` on success, or
+- remove a possibly committed row by vault path and skip the video on an ordinary
+  insertion failure.
+
+If reservation is cancelled, `reserveVideos` will remove every attempted reservation
+in a non-cancellable cleanup block before rethrowing.
+
+### Move phase
+
+`moveReservedVideos` will call `MediaOperationsService.moveMedia` once for the entire
+batch and convert its result into a private sealed `MoveOutcome`:
+
+- `Completed` contains the per-URI move results.
+- `Failed` represents an exception with an unknown partial result.
+- `Cancelled` retains the original `CancellationException`.
+
+The outcome makes control flow explicit while keeping exception handling out of the
+public orchestration method.
+
+### Reconciliation phase
+
+`reconcileReservations` will accept `MoveOutcome`.
+
+- For `Completed`, it will retain only rows whose exact destination was confirmed.
+- For `Failed` or `Cancelled`, it will retain rows whose destination exists because a
+  move may have committed before the exception became observable.
+- It will delete all other reserved rows in a non-cancellable cleanup block.
+
+After reconciliation, `Cancelled` will rethrow its original exception. Other outcomes
+will return normally, matching current behavior.
+
+## Verification
+
+The existing repository instrumentation tests remain the behavioral contract:
+
+- database insertion failure preserves the source,
+- matching source names use different vault files,
+- move failure preserves the source and removes the reservation,
+- insertion cancellation removes a possibly committed reservation,
+- move cancellation preserves uncommitted sources and removes reservations.
+
+Run:
+
+```text
+:core:data:connectedDebugAndroidTest
+:core:media:connectedDebugAndroidTest
+ktlintCheck
+testDebugUnitTest
+:app:assembleDebug
+```
+
+No production behavior or public API is expected to change.


### PR DESCRIPTION
## Summary
- generate unique UUID-backed vault destinations to prevent same-name collisions
- reserve database rows before destructive file operations and reconcile failed or cancelled moves
- copy, sync, and verify each vault file before deleting its source
- keep LocalVaultRepository readable through explicit reservation, move, and reconciliation phases
- serialize vault mutations and hide pending reservations until their files commit
- preserve committed batch results while leaving uncommitted sources untouched

## Reproduction
Issue #1828 was reproduced with two hash-distinct videos sharing the same filename. The old flow overwrote the first vault path and then crashed on the hidden_video.vault_path unique constraint after moving the source.

## Verification
- core:data and core:media production Kotlin compilation
- core:data and core:media instrumentation-test Kotlin compilation
- 25 JVM tests with zero failures
- project ktlintCheck
- app debug APK assembly
- earlier disposable Android 16 validation of the original collision, permission-denial, failure, and cancellation paths
- independent task review and whole-branch review

Closes #1828