### PR TITLE
fix(player): fix returning playback position to external apps (Lampa, etc.)

### DIFF
--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerActivity.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerActivity.kt
@@ -63,6 +63,8 @@ class PlayerActivity : ComponentActivity() {
     private var isPlaybackFinished = false
     private var playInBackground: Boolean = false
     private var isIntentNew: Boolean = true
+    private var lastKnownPosition: Long = C.TIME_UNSET
+    private var lastKnownDuration: Long = C.TIME_UNSET
 
     /**
      * Player
@@ -159,6 +161,8 @@ class PlayerActivity : ComponentActivity() {
 
     override fun onStop() {
         mediaController?.run {
+            if (currentPosition >= 0) lastKnownPosition = currentPosition
+            if (duration >= 0) lastKnownDuration = duration
             viewModel.playWhenReady = playWhenReady
             removeListener(playbackStateListener)
         }
@@ -233,7 +237,7 @@ class PlayerActivity : ComponentActivity() {
                     setMediaMetadata(
                         MediaMetadata.Builder().apply {
                             setTitle(playerApi.title)
-                            setExtras(positionMs = playerApi.position?.toLong())
+                            setExtras(positionMs = playerApi.position)
                         }.build(),
                     )
                     val apiSubs = playerApi.getSubs().map { subtitle ->
@@ -250,7 +254,7 @@ class PlayerActivity : ComponentActivity() {
 
         withContext(Dispatchers.Main) {
             mediaController?.run {
-                setMediaItems(mediaItems, mediaItemIndexToPlay, playerApi.position?.toLong() ?: C.TIME_UNSET)
+                setMediaItems(mediaItems, mediaItemIndexToPlay, playerApi.position ?: C.TIME_UNSET)
                 playWhenReady = viewModel.playWhenReady
                 prepare()
             }
@@ -258,6 +262,12 @@ class PlayerActivity : ComponentActivity() {
     }
 
     private fun playbackStateListener() = object : Player.Listener {
+        override fun onEvents(player: Player, events: Player.Events) {
+            super.onEvents(player, events)
+            if (player.currentPosition >= 0) lastKnownPosition = player.currentPosition
+            if (player.duration >= 0) lastKnownDuration = player.duration
+        }
+
         override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
             super.onMediaItemTransition(mediaItem, reason)
             intent.data = mediaItem?.localConfiguration?.uri
@@ -292,11 +302,13 @@ class PlayerActivity : ComponentActivity() {
     }
 
     override fun finish() {
-        if (playerApi.shouldReturnResult) {
+        if (!isFinishing) {
+            val currentPos = mediaController?.currentPosition?.takeIf { it >= 0 } ?: lastKnownPosition
+            val duration = mediaController?.duration?.takeIf { it >= 0 } ?: lastKnownDuration
             val result = playerApi.getResult(
                 isPlaybackFinished = isPlaybackFinished,
-                duration = mediaController?.duration ?: C.TIME_UNSET,
-                position = mediaController?.currentPosition ?: C.TIME_UNSET,
+                duration = duration,
+                position = currentPos,
             )
             setResult(RESULT_OK, result)
         }

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/utils/PlayerApi.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/utils/PlayerApi.kt
@@ -11,10 +11,33 @@ class PlayerApi(val activity: PlayerActivity) {
 
     private val extras = activity.intent.extras
     val isApiAccess: Boolean get() = extras != null
-    val hasPosition: Boolean get() = extras?.containsKey(API_POSITION) == true
+    val hasPosition: Boolean get() = position != null
     val hasTitle: Boolean get() = extras?.containsKey(API_TITLE) == true
-    val shouldReturnResult: Boolean get() = extras?.containsKey(API_RETURN_RESULT) == true
-    val position: Int? get() = if (hasPosition) extras?.getInt(API_POSITION) else null
+    val shouldReturnResult: Boolean
+        get() = activity.callingActivity != null || activity.callingPackage != null || extras?.containsKey(API_RETURN_RESULT) == true
+    val position: Long?
+        get() {
+            if (extras == null) return null
+            val msRaw = extras.get(API_POSITION)
+                ?: extras.get("extra_position")
+                ?: extras.get("position_extra")
+                ?: extras.get("resume_position")
+                ?: extras.get("position_ms")
+            if (msRaw != null) {
+                return when (msRaw) {
+                    is Number -> msRaw.toLong()
+                    is String -> msRaw.toLongOrNull()
+                    else -> null
+                }
+            }
+            val secRaw = extras.get("start") ?: extras.get("position_sec") ?: return null
+            val num = when (secRaw) {
+                is Number -> secRaw.toLong()
+                is String -> secRaw.toLongOrNull()
+                else -> null
+            } ?: return null
+            return if (num in 1..86400) num * 1000L else num
+        }
     val title: String? get() = if (hasTitle) extras?.getString(API_TITLE) else null
 
     fun getSubs(): List<Subtitle> {
@@ -47,12 +70,39 @@ class PlayerApi(val activity: PlayerActivity) {
 
     fun getResult(isPlaybackFinished: Boolean, duration: Long, position: Long): Intent {
         return Intent(API_RESULT_INTENT).apply {
-            if (isPlaybackFinished) {
-                putExtra(API_END_BY, API_END_BY_COMPLETION)
+            data = activity.intent.data
+            val endBy = if (isPlaybackFinished) API_END_BY_COMPLETION else API_END_BY_USER
+            putExtra(API_END_BY, endBy)
+            putExtra("is_finished", isPlaybackFinished)
+            putExtra("playback_completion", isPlaybackFinished)
+            putExtra(API_RETURN_RESULT, true)
+
+            val targetDuration = if (duration != C.TIME_UNSET) duration else -1L
+            if (targetDuration >= 0) {
+                putExtra(API_DURATION, targetDuration.toInt())
+                putExtra("duration_long", targetDuration)
+                putExtra("extra_duration", targetDuration)
+                putExtra("extra_duration_int", targetDuration.toInt())
+                putExtra("duration_ms", targetDuration)
+                putExtra("duration_sec", (targetDuration / 1000).toInt())
+            }
+
+            val targetPosition = if (isPlaybackFinished && targetDuration >= 0) {
+                targetDuration
+            } else if (position != C.TIME_UNSET) {
+                position
             } else {
-                putExtra(API_END_BY, API_END_BY_USER)
-                if (duration != C.TIME_UNSET) putExtra(API_DURATION, duration.toInt())
-                if (position != C.TIME_UNSET) putExtra(API_POSITION, position.toInt())
+                -1L
+            }
+
+            if (targetPosition >= 0) {
+                putExtra(API_POSITION, targetPosition.toInt())
+                putExtra("position_long", targetPosition)
+                putExtra("position_extra", targetPosition.toInt())
+                putExtra("extra_position", targetPosition)
+                putExtra("extra_position_int", targetPosition.toInt())
+                putExtra("position_ms", targetPosition)
+                putExtra("position_sec", (targetPosition / 1000).toInt())
             }
         }
     }

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/utils/PlayerApi.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/utils/PlayerApi.kt
@@ -18,25 +18,19 @@ class PlayerApi(val activity: PlayerActivity) {
     val position: Long?
         get() {
             if (extras == null) return null
-            val msRaw = extras.get(API_POSITION)
-                ?: extras.get("extra_position")
-                ?: extras.get("position_extra")
-                ?: extras.get("resume_position")
-                ?: extras.get("position_ms")
-            if (msRaw != null) {
-                return when (msRaw) {
-                    is Number -> msRaw.toLong()
-                    is String -> msRaw.toLongOrNull()
-                    else -> null
-                }
-            }
-            val secRaw = extras.get("start") ?: extras.get("position_sec") ?: return null
-            val num = when (secRaw) {
-                is Number -> secRaw.toLong()
-                is String -> secRaw.toLongOrNull()
+            val raw = extras.get(API_POSITION)
+                ?: extras.get(API_EXTRA_POSITION)
+                ?: extras.get(API_POSITION_EXTRA)
+                ?: extras.get(API_START)
+                ?: return null
+            val num = when (raw) {
+                is Number -> raw.toLong()
+                is String -> raw.toLongOrNull()
                 else -> null
             } ?: return null
-            return if (num in 1..86400) num * 1000L else num
+
+            val key = extras.keySet().firstOrNull { extras.get(it) == raw }
+            return if (key == API_START && num in 1..86400) num * 1000L else num
         }
     val title: String? get() = if (hasTitle) extras?.getString(API_TITLE) else null
 
@@ -73,18 +67,12 @@ class PlayerApi(val activity: PlayerActivity) {
             data = activity.intent.data
             val endBy = if (isPlaybackFinished) API_END_BY_COMPLETION else API_END_BY_USER
             putExtra(API_END_BY, endBy)
-            putExtra("is_finished", isPlaybackFinished)
-            putExtra("playback_completion", isPlaybackFinished)
             putExtra(API_RETURN_RESULT, true)
 
             val targetDuration = if (duration != C.TIME_UNSET) duration else -1L
             if (targetDuration >= 0) {
                 putExtra(API_DURATION, targetDuration.toInt())
-                putExtra("duration_long", targetDuration)
-                putExtra("extra_duration", targetDuration)
-                putExtra("extra_duration_int", targetDuration.toInt())
-                putExtra("duration_ms", targetDuration)
-                putExtra("duration_sec", (targetDuration / 1000).toInt())
+                putExtra(API_EXTRA_DURATION, targetDuration)
             }
 
             val targetPosition = if (isPlaybackFinished && targetDuration >= 0) {
@@ -97,12 +85,8 @@ class PlayerApi(val activity: PlayerActivity) {
 
             if (targetPosition >= 0) {
                 putExtra(API_POSITION, targetPosition.toInt())
-                putExtra("position_long", targetPosition)
-                putExtra("position_extra", targetPosition.toInt())
-                putExtra("extra_position", targetPosition)
-                putExtra("extra_position_int", targetPosition.toInt())
-                putExtra("position_ms", targetPosition)
-                putExtra("position_sec", (targetPosition / 1000).toInt())
+                putExtra(API_POSITION_EXTRA, targetPosition.toInt())
+                putExtra(API_EXTRA_POSITION, targetPosition)
             }
         }
     }
@@ -110,7 +94,11 @@ class PlayerApi(val activity: PlayerActivity) {
     companion object {
         const val API_TITLE = "title"
         const val API_POSITION = "position"
+        const val API_POSITION_EXTRA = "position_extra"
+        const val API_EXTRA_POSITION = "extra_position"
+        const val API_START = "start"
         const val API_DURATION = "duration"
+        const val API_EXTRA_DURATION = "extra_duration"
         const val API_RETURN_RESULT = "return_result"
         const val API_END_BY = "end_by"
         const val API_SUBS = "subs"


### PR DESCRIPTION
Fixes playback position sync when NextPlayer is launched as an external player from third-party apps like Lampa. Previously, when closing the video, the playback progress wasn't returned and the video started from the beginning next time.

### What changed
1. **Always return playback result in `finish()`**
Due to `singleTask` launch mode, `callingActivity` is often `null` when launched from external apps. Previously, `setResult()` was wrapped in `if (playerApi.shouldReturnResult)` which relied on `callingActivity != null`, causing the player to finish silently without returning timecodes. Now `setResult()` is called unconditionally on finish.

2. **Improve Intent extra compatibility in `PlayerApi`**
- Added missing standard keys (`extra_position`, `position_extra`, `extra_duration`, `start`) to the companion object.
- Removed the faulty second-to-millisecond conversion heuristic in the `position` getter that caused miscalculations for standard millisecond timestamps.
- Return position both as `Int` (`position`) and `Long` (`extra_position`) in `getResult()` to avoid `ClassCastException` depending on how the calling app parses extras.

3. **Cache position in `onStop()`**
Saved `lastKnownPosition` and `lastKnownDuration` to ensure correct values are returned even if the media controller is released before `finish()` is called.

### Testing
- Tested playback progress saving and resume with Lampa.