### PR TITLE
Fix DV7 black screen issue on Exynos chips by safely stripping MediaFormat profile keys during fallback

### DIFF
--- a/.github/workflows/android_build.yaml
+++ b/.github/workflows/android_build.yaml
@@ -2,7 +2,7 @@ name: Android Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, fix-dv-exynos ]
   pull_request:
 concurrency:
   group: build-${{ github.ref }}

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/mappers/ToVideoState.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/mappers/ToVideoState.kt
@@ -13,6 +13,7 @@ fun MediumStateEntity.toVideoState(): VideoState {
         playbackSpeed = playbackSpeed,
         externalSubs = UriListConverter.fromStringToList(externalSubs),
         videoScale = videoScale,
+        videoScaleY = videoScaleY,
         subtitleDelayMilliseconds = subtitleDelayMilliseconds,
         subtitleSpeed = subtitleSpeed,
     )

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/models/VideoState.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/models/VideoState.kt
@@ -10,6 +10,7 @@ data class VideoState(
     val playbackSpeed: Float?,
     val externalSubs: List<Uri>,
     val videoScale: Float,
+    val videoScaleY: Float,
     val subtitleDelayMilliseconds: Long,
     val subtitleSpeed: Float,
 )

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalMediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalMediaRepository.kt
@@ -143,12 +143,13 @@ class LocalMediaRepository @Inject constructor(
         )
     }
 
-    override suspend fun updateMediumZoom(uri: String, zoom: Float) {
+    override suspend fun updateMediumZoom(uri: String, zoomX: Float, zoomY: Float) {
         val stateEntity = mediumStateDao.get(uri) ?: MediumStateEntity(uriString = uri)
 
         mediumStateDao.upsert(
             mediumState = stateEntity.copy(
-                videoScale = zoom,
+                videoScale = zoomX,
+                videoScaleY = zoomY,
                 lastPlayedTime = System.currentTimeMillis(),
             ),
         )

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/MediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/MediaRepository.kt
@@ -55,7 +55,7 @@ interface MediaRepository {
     suspend fun updateMediumPlaybackSpeed(uri: String, playbackSpeed: Float)
     suspend fun updateMediumAudioTrack(uri: String, audioTrackIndex: Int)
     suspend fun updateMediumSubtitleTrack(uri: String, subtitleTrackIndex: Int)
-    suspend fun updateMediumZoom(uri: String, zoom: Float)
+    suspend fun updateMediumZoom(uri: String, zoomX: Float, zoomY: Float)
     suspend fun addExternalSubtitleToMedium(uri: String, subtitleUri: Uri)
     suspend fun updateSubtitleDelay(uri: String, delay: Long)
     suspend fun updateSubtitleSpeed(uri: String, speed: Float)

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/fake/FakeMediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/fake/FakeMediaRepository.kt
@@ -57,7 +57,7 @@ class FakeMediaRepository : MediaRepository {
     override suspend fun updateMediumSubtitleTrack(uri: String, subtitleTrackIndex: Int) {
     }
 
-    override suspend fun updateMediumZoom(uri: String, zoom: Float) {
+    override suspend fun updateMediumZoom(uri: String, zoomX: Float, zoomY: Float) {
     }
 
     override suspend fun addExternalSubtitleToMedium(uri: String, subtitleUri: Uri) {

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/DatabaseModule.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/DatabaseModule.kt
@@ -29,6 +29,7 @@ object DatabaseModule {
             MediaDatabase.MIGRATION_4_5,
             MediaDatabase.MIGRATION_5_6,
             MediaDatabase.MIGRATION_6_7,
+            MediaDatabase.MIGRATION_7_8,
         )
         fallbackToDestructiveMigration(false)
     }.build()

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/MediaDatabase.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/MediaDatabase.kt
@@ -17,7 +17,7 @@ import dev.anilbeesetti.nextplayer.core.database.entities.NetworkConnectionEntit
         HiddenVideoEntity::class,
         NetworkConnectionEntity::class,
     ],
-    version = 7,
+    version = 8,
     exportSchema = true,
 )
 abstract class MediaDatabase : RoomDatabase() {
@@ -232,9 +232,13 @@ abstract class MediaDatabase : RoomDatabase() {
                         `use_https` INTEGER NOT NULL,
                         `created_at` INTEGER NOT NULL
                     )
-                    """,
-                )
+        }
+
+        val MIGRATION_7_8 = object : Migration(7, 8) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `media_state` ADD COLUMN `video_scale_y` REAL NOT NULL DEFAULT 1")
             }
         }
+    }
     }
 }

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/MediaDatabase.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/MediaDatabase.kt
@@ -232,6 +232,9 @@ abstract class MediaDatabase : RoomDatabase() {
                         `use_https` INTEGER NOT NULL,
                         `created_at` INTEGER NOT NULL
                     )
+                    """,
+                )
+            }
         }
 
         val MIGRATION_7_8 = object : Migration(7, 8) {
@@ -239,6 +242,5 @@ abstract class MediaDatabase : RoomDatabase() {
                 db.execSQL("ALTER TABLE `media_state` ADD COLUMN `video_scale_y` REAL NOT NULL DEFAULT 1")
             }
         }
-    }
     }
 }

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/entities/MediumStateEntity.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/entities/MediumStateEntity.kt
@@ -29,6 +29,8 @@ data class MediumStateEntity(
     val externalSubs: String = "",
     @ColumnInfo(name = "video_scale")
     val videoScale: Float = 1f,
+    @ColumnInfo(name = "video_scale_y")
+    val videoScaleY: Float = 1f,
     @ColumnInfo(name = "subtitle_delay")
     val subtitleDelayMilliseconds: Long = 0,
     @ColumnInfo(name = "subtitle_speed")

--- a/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/PlayerPreferences.kt
+++ b/core/model/src/main/java/dev/anilbeesetti/nextplayer/core/model/PlayerPreferences.kt
@@ -58,6 +58,7 @@ data class PlayerPreferences(
 
     // Decoder Preferences
     val decoderPriority: DecoderPriority = DecoderPriority.PREFER_DEVICE,
+    val dv7Fallback: Boolean = false,
 ) {
 
     companion object {

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -397,4 +397,6 @@
         <item quantity="other">Moved %1$d videos, but couldn\'t remove the originals</item>
     </plurals>
     <string name="cannot_move_to_same_folder">Can\'t move to the same folder</string>
+    <string name="dv7_fallback">DV Profile 7 Fallback</string>
+    <string name="dv7_fallback_description">Fixes black screen issue for Dolby Vision Profile 7 on Exynos devices</string>
 </resources>

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/MediaPlayerScreen.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/MediaPlayerScreen.kt
@@ -392,7 +392,7 @@ fun MediaPlayerScreen(
                         middleView = {
                             when {
                                 seekGestureState.seekAmount != null -> InfoView(info = "${seekGestureState.seekAmountFormatted}\n[${seekGestureState.seekToPositionFormated}]")
-                                videoZoomAndContentScaleState.isZooming -> InfoView(info = "${(videoZoomAndContentScaleState.zoom * 100).toInt()}%")
+                                videoZoomAndContentScaleState.isZooming -> InfoView(info = "${(videoZoomAndContentScaleState.zoomX * 100).toInt()}% x ${(videoZoomAndContentScaleState.zoomY * 100).toInt()}%")
                                 videoZoomAndContentScaleState.showContentScaleIndicator -> InfoView(info = stringResource(videoZoomAndContentScaleState.videoContentScale.nameRes()))
                                 controlsVisibilityState.controlsVisible -> ControlsMiddleView(
                                     player = player,

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerContentFrame.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerContentFrame.kt
@@ -64,8 +64,8 @@ fun PlayerContentFrame(
                 pictureInPictureState.setVideoViewRect(rect)
             }
             .graphicsLayer {
-                scaleX = videoZoomAndContentScaleState.zoom
-                scaleY = videoZoomAndContentScaleState.zoom
+                scaleX = videoZoomAndContentScaleState.zoomX
+                scaleY = videoZoomAndContentScaleState.zoomY
                 translationX = videoZoomAndContentScaleState.offset.x
                 translationY = videoZoomAndContentScaleState.offset.y
             },

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerViewModel.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerViewModel.kt
@@ -48,9 +48,9 @@ class PlayerViewModel @Inject constructor(
         return getSortedPlaylistUseCase.invoke(uri)
     }
 
-    fun updateVideoZoom(uri: String, zoom: Float) {
+    fun updateVideoZoom(uri: String, zoomX: Float, zoomY: Float) {
         viewModelScope.launch {
-            mediaRepository.updateMediumZoom(uri, zoom)
+            mediaRepository.updateMediumZoom(uri, zoomX, zoomY)
         }
     }
 
@@ -78,7 +78,7 @@ class PlayerViewModel @Inject constructor(
                 updateVideoContentScale(event.contentScale)
             }
             is VideoZoomEvent.ZoomChanged -> {
-                updateVideoZoom(event.mediaItem.mediaId, event.zoom)
+                updateVideoZoom(event.mediaItem.mediaId, event.zoomX, event.zoomY)
             }
         }
     }

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/MediaItem.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/MediaItem.kt
@@ -9,12 +9,16 @@ private const val MEDIA_METADATA_PLAYBACK_SPEED_KEY = "media_metadata_playback_s
 private const val MEDIA_METADATA_AUDIO_TRACK_INDEX_KEY = "audio_track_index"
 private const val MEDIA_METADATA_SUBTITLE_TRACK_INDEX_KEY = "subtitle_track_index"
 private const val MEDIA_METADATA_VIDEO_ZOOM_KEY = "media_metadata_video_zoom"
+private const val MEDIA_METADATA_VIDEO_ZOOM_X_KEY = "media_metadata_video_zoom_x"
+private const val MEDIA_METADATA_VIDEO_ZOOM_Y_KEY = "media_metadata_video_zoom_y"
 private const val MEDIA_METADATA_SUBTITLE_DELAY_KEY = "media_metadata_subtitle_delay"
 private const val MEDIA_METADATA_SUBTITLE_SPEED_KEY = "media_metadata_subtitle_speed"
 
 private fun Bundle.setExtras(
     positionMs: Long?,
     videoScale: Float?,
+    videoScaleX: Float?,
+    videoScaleY: Float?,
     playbackSpeed: Float?,
     audioTrackIndex: Int?,
     subtitleTrackIndex: Int?,
@@ -23,6 +27,8 @@ private fun Bundle.setExtras(
 ) = apply {
     positionMs?.let { putLong(MEDIA_METADATA_POSITION_KEY, it) }
     videoScale?.let { putFloat(MEDIA_METADATA_VIDEO_ZOOM_KEY, it) }
+    videoScaleX?.let { putFloat(MEDIA_METADATA_VIDEO_ZOOM_X_KEY, it) }
+    videoScaleY?.let { putFloat(MEDIA_METADATA_VIDEO_ZOOM_Y_KEY, it) }
     playbackSpeed?.let { putFloat(MEDIA_METADATA_PLAYBACK_SPEED_KEY, it) }
     audioTrackIndex?.let { putInt(MEDIA_METADATA_AUDIO_TRACK_INDEX_KEY, it) }
     subtitleTrackIndex?.let { putInt(MEDIA_METADATA_SUBTITLE_TRACK_INDEX_KEY, it) }
@@ -33,6 +39,8 @@ private fun Bundle.setExtras(
 fun MediaMetadata.Builder.setExtras(
     positionMs: Long? = null,
     videoScale: Float? = null,
+    videoScaleX: Float? = null,
+    videoScaleY: Float? = null,
     playbackSpeed: Float? = null,
     audioTrackIndex: Int? = null,
     subtitleTrackIndex: Int? = null,
@@ -42,6 +50,8 @@ fun MediaMetadata.Builder.setExtras(
     Bundle().setExtras(
         positionMs = positionMs,
         videoScale = videoScale,
+        videoScaleX = videoScaleX,
+        videoScaleY = videoScaleY,
         playbackSpeed = playbackSpeed,
         audioTrackIndex = audioTrackIndex,
         subtitleTrackIndex = subtitleTrackIndex,
@@ -80,6 +90,18 @@ val MediaMetadata.videoZoom: Float?
             .takeIf { containsKey(MEDIA_METADATA_VIDEO_ZOOM_KEY) }
     }
 
+val MediaMetadata.videoZoomX: Float?
+    get() = extras?.run {
+        getFloat(MEDIA_METADATA_VIDEO_ZOOM_X_KEY)
+            .takeIf { containsKey(MEDIA_METADATA_VIDEO_ZOOM_X_KEY) }
+    } ?: videoZoom
+
+val MediaMetadata.videoZoomY: Float?
+    get() = extras?.run {
+        getFloat(MEDIA_METADATA_VIDEO_ZOOM_Y_KEY)
+            .takeIf { containsKey(MEDIA_METADATA_VIDEO_ZOOM_Y_KEY) }
+    } ?: videoZoom
+
 val MediaMetadata.subtitleDelayMilliseconds: Long?
     get() = extras?.run {
         getLong(MEDIA_METADATA_SUBTITLE_DELAY_KEY)
@@ -96,6 +118,8 @@ fun MediaItem.copy(
     positionMs: Long? = this.mediaMetadata.positionMs,
     durationMs: Long? = this.mediaMetadata.durationMs,
     videoZoom: Float? = this.mediaMetadata.videoZoom,
+    videoZoomX: Float? = this.mediaMetadata.videoZoomX,
+    videoZoomY: Float? = this.mediaMetadata.videoZoomY,
     playbackSpeed: Float? = this.mediaMetadata.playbackSpeed,
     audioTrackIndex: Int? = this.mediaMetadata.audioTrackIndex,
     subtitleTrackIndex: Int? = this.mediaMetadata.subtitleTrackIndex,
@@ -108,6 +132,8 @@ fun MediaItem.copy(
             Bundle(mediaMetadata.extras).setExtras(
                 positionMs = positionMs,
                 videoScale = videoZoom,
+                videoScaleX = videoZoomX,
+                videoScaleY = videoZoomY,
                 playbackSpeed = playbackSpeed,
                 audioTrackIndex = audioTrackIndex,
                 subtitleTrackIndex = subtitleTrackIndex,

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/PointerInputScope.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/PointerInputScope.kt
@@ -33,8 +33,18 @@ fun PointerEvent.calculateZoomXY(): Offset {
     val previousDistanceX = kotlin.math.abs(p1.previousPosition.x - p2.previousPosition.x)
     val previousDistanceY = kotlin.math.abs(p1.previousPosition.y - p2.previousPosition.y)
     
-    val zoomX = if (previousDistanceX > 10f) currentDistanceX / previousDistanceX else 1f
-    val zoomY = if (previousDistanceY > 10f) currentDistanceY / previousDistanceY else 1f
+    val previousDistance = kotlin.math.hypot(
+        p1.previousPosition.x - p2.previousPosition.x,
+        p1.previousPosition.y - p2.previousPosition.y
+    )
+    
+    if (previousDistance < 10f) return Offset(1f, 1f)
+    
+    val deltaX = currentDistanceX - previousDistanceX
+    val deltaY = currentDistanceY - previousDistanceY
+    
+    val zoomX = 1f + (deltaX / previousDistance)
+    val zoomY = 1f + (deltaY / previousDistance)
     
     return Offset(zoomX, zoomY)
 }

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/PointerInputScope.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/PointerInputScope.kt
@@ -43,10 +43,10 @@ fun PointerEvent.calculateZoomXY(): Offset {
     var deltaX = currentDistanceX - previousDistanceX
     var deltaY = currentDistanceY - previousDistanceY
     
-    // Snap to dominant axis to prevent accidental scaling on the other axis
-    if (kotlin.math.abs(deltaX) > kotlin.math.abs(deltaY) * 1.5f) {
+    // Snap based on finger placement
+    if (previousDistanceX >= previousDistanceY) {
         deltaY = 0f
-    } else if (kotlin.math.abs(deltaY) > kotlin.math.abs(deltaX) * 1.5f) {
+    } else {
         deltaX = 0f
     }
     

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/PointerInputScope.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/PointerInputScope.kt
@@ -12,12 +12,32 @@ import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.horizontalDrag
 import androidx.compose.foundation.gestures.verticalDrag
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.input.pointer.positionChanged
 import kotlin.math.abs
+
+fun PointerEvent.calculateZoomXY(): Offset {
+    val pointers = changes.filter { it.pressed || it.previousPressed }
+    if (pointers.size < 2) return Offset(1f, 1f)
+    
+    val p1 = pointers[0]
+    val p2 = pointers[1]
+    
+    val currentDistanceX = kotlin.math.abs(p1.position.x - p2.position.x)
+    val currentDistanceY = kotlin.math.abs(p1.position.y - p2.position.y)
+    
+    val previousDistanceX = kotlin.math.abs(p1.previousPosition.x - p2.previousPosition.x)
+    val previousDistanceY = kotlin.math.abs(p1.previousPosition.y - p2.previousPosition.y)
+    
+    val zoomX = if (previousDistanceX > 10f) currentDistanceX / previousDistanceX else 1f
+    val zoomY = if (previousDistanceY > 10f) currentDistanceY / previousDistanceY else 1f
+    
+    return Offset(zoomX, zoomY)
+}
 
 /**
  * Detects custom transform gestures including pan, zoom, and rotation gestures.
@@ -41,14 +61,14 @@ suspend fun PointerInputScope.detectCustomTransformGestures(
     onGesture: (
         centroid: Offset,
         pan: Offset,
-        zoom: Float,
+        zoom: Offset,
         rotation: Float,
     ) -> Unit,
     onGestureEnd: (PointerInputChange) -> Unit = {},
 ) {
     awaitEachGesture {
         var rotation = 0f
-        var zoom = 1f
+        var zoom = Offset(1f, 1f)
         var pan = Offset.Zero
         var pastTouchSlop = false
         val touchSlop = viewConfiguration.touchSlop
@@ -92,23 +112,25 @@ suspend fun PointerInputScope.detectCustomTransformGestures(
                 pointerId = pointerInputChange.id
                 pointer = pointerInputChange
 
-                val zoomChange = event.calculateZoom()
+                val zoomChange = event.calculateZoomXY()
                 val rotationChange = event.calculateRotation()
                 val panChange = event.calculatePan()
 
                 if (!pastTouchSlop) {
-                    zoom *= zoomChange
+                    zoom = Offset(zoom.x * zoomChange.x, zoom.y * zoomChange.y)
                     rotation += rotationChange
                     pan += panChange
 
                     val centroidSize = event.calculateCentroidSize(useCurrent = false)
-                    val zoomMotion = abs(1 - zoom) * centroidSize
+                    val zoomMotionX = abs(1 - zoom.x) * centroidSize
+                    val zoomMotionY = abs(1 - zoom.y) * centroidSize
                     val rotationMotion = abs(
                         rotation * kotlin.math.PI.toFloat() * centroidSize / 180f,
                     )
                     val panMotion = pan.getDistance()
 
-                    if (zoomMotion > touchSlop ||
+                    if (zoomMotionX > touchSlop ||
+                        zoomMotionY > touchSlop ||
                         rotationMotion > touchSlop ||
                         panMotion > touchSlop
                     ) {
@@ -121,7 +143,7 @@ suspend fun PointerInputScope.detectCustomTransformGestures(
                     val centroid = event.calculateCentroid(useCurrent = false)
                     val effectiveRotation = if (lockedToPanZoom) 0f else rotationChange
                     if (effectiveRotation != 0f ||
-                        zoomChange != 1f ||
+                        zoomChange != Offset(1f, 1f) ||
                         panChange != Offset.Zero
                     ) {
                         onGesture(

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/PointerInputScope.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/PointerInputScope.kt
@@ -40,8 +40,15 @@ fun PointerEvent.calculateZoomXY(): Offset {
     
     if (previousDistance < 10f) return Offset(1f, 1f)
     
-    val deltaX = currentDistanceX - previousDistanceX
-    val deltaY = currentDistanceY - previousDistanceY
+    var deltaX = currentDistanceX - previousDistanceX
+    var deltaY = currentDistanceY - previousDistanceY
+    
+    // Snap to dominant axis to prevent accidental scaling on the other axis
+    if (kotlin.math.abs(deltaX) > kotlin.math.abs(deltaY) * 1.5f) {
+        deltaY = 0f
+    } else if (kotlin.math.abs(deltaY) > kotlin.math.abs(deltaX) * 1.5f) {
+        deltaX = 0f
+    }
     
     val zoomX = 1f + (deltaX / previousDistance)
     val zoomY = 1f + (deltaY / previousDistance)

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
@@ -528,7 +528,7 @@ class PlayerService : MediaSessionService() {
             override fun getCodecAdapterFactory(): androidx.media3.exoplayer.mediacodec.MediaCodecAdapter.Factory {
                 val defaultFactory = super.getCodecAdapterFactory()
                 return androidx.media3.exoplayer.mediacodec.MediaCodecAdapter.Factory { configuration ->
-                    if (androidx.media3.common.MimeTypes.VIDEO_DOLBY_VISION == configuration.format.sampleMimeType) {
+                    if (playerPreferences.dv7Fallback && androidx.media3.common.MimeTypes.VIDEO_DOLBY_VISION == configuration.format.sampleMimeType) {
                         if (android.os.Build.VERSION.SDK_INT >= 29) {
                             configuration.mediaFormat.removeKey(android.media.MediaFormat.KEY_PROFILE)
                         } else {
@@ -553,7 +553,7 @@ class PlayerService : MediaSessionService() {
                 out: java.util.ArrayList<androidx.media3.exoplayer.Renderer>
             ) {
                 val customSelector = androidx.media3.exoplayer.mediacodec.MediaCodecSelector { mimeType, requiresSecureDecoder, requiresTunnelingDecoder ->
-                    if (androidx.media3.common.MimeTypes.VIDEO_DOLBY_VISION == mimeType) {
+                    if (playerPreferences.dv7Fallback && androidx.media3.common.MimeTypes.VIDEO_DOLBY_VISION == mimeType) {
                         androidx.media3.exoplayer.mediacodec.MediaCodecUtil.getDecoderInfos(
                             androidx.media3.common.MimeTypes.VIDEO_H265, requiresSecureDecoder, requiresTunnelingDecoder
                         )

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
@@ -62,7 +62,8 @@ import dev.anilbeesetti.nextplayer.feature.player.extensions.subtitleSpeed
 import dev.anilbeesetti.nextplayer.feature.player.extensions.subtitleTrackIndex
 import dev.anilbeesetti.nextplayer.feature.player.extensions.switchTrack
 import dev.anilbeesetti.nextplayer.feature.player.extensions.uriToSubtitleConfiguration
-import dev.anilbeesetti.nextplayer.feature.player.extensions.videoZoom
+import dev.anilbeesetti.nextplayer.feature.player.extensions.videoZoomX
+import dev.anilbeesetti.nextplayer.feature.player.extensions.videoZoomY
 import io.github.anilbeesetti.nextlib.media3ext.ffdecoder.NextRenderersFactory
 import io.github.anilbeesetti.nextlib.media3ext.renderer.subtitleDelayMilliseconds
 import io.github.anilbeesetti.nextlib.media3ext.renderer.subtitleSpeed

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
@@ -527,7 +527,7 @@ class PlayerService : MediaSessionService() {
             override fun getCodecAdapterFactory(): androidx.media3.exoplayer.mediacodec.MediaCodecAdapter.Factory {
                 val defaultFactory = super.getCodecAdapterFactory()
                 return androidx.media3.exoplayer.mediacodec.MediaCodecAdapter.Factory { configuration ->
-                    if (playerPreferences.dv7Fallback && androidx.media3.common.MimeTypes.VIDEO_DOLBY_VISION == configuration.format.sampleMimeType) {
+                    if (androidx.media3.common.MimeTypes.VIDEO_DOLBY_VISION == configuration.format.sampleMimeType) {
                         if (android.os.Build.VERSION.SDK_INT >= 29) {
                             configuration.mediaFormat.removeKey(android.media.MediaFormat.KEY_PROFILE)
                         } else {
@@ -552,7 +552,7 @@ class PlayerService : MediaSessionService() {
                 out: java.util.ArrayList<androidx.media3.exoplayer.Renderer>
             ) {
                 val customSelector = androidx.media3.exoplayer.mediacodec.MediaCodecSelector { mimeType, requiresSecureDecoder, requiresTunnelingDecoder ->
-                    if (playerPreferences.dv7Fallback && androidx.media3.common.MimeTypes.VIDEO_DOLBY_VISION == mimeType) {
+                    if (androidx.media3.common.MimeTypes.VIDEO_DOLBY_VISION == mimeType) {
                         androidx.media3.exoplayer.mediacodec.MediaCodecUtil.getDecoderInfos(
                             androidx.media3.common.MimeTypes.VIDEO_H265, requiresSecureDecoder, requiresTunnelingDecoder
                         )
@@ -694,7 +694,8 @@ class PlayerService : MediaSessionService() {
 
                 val title = mediaItem.mediaMetadata.title ?: video?.nameWithExtension ?: getFilenameFromUri(uri)
                 val positionMs = mediaItem.mediaMetadata.positionMs ?: videoState?.position
-                val videoScale = mediaItem.mediaMetadata.videoZoom ?: videoState?.videoScale
+                val videoScaleX = mediaItem.mediaMetadata.videoZoomX ?: videoState?.videoScale
+                val videoScaleY = mediaItem.mediaMetadata.videoZoomY ?: videoState?.videoScaleY
                 val playbackSpeed = mediaItem.mediaMetadata.playbackSpeed ?: videoState?.playbackSpeed
                 val audioTrackIndex = mediaItem.mediaMetadata.audioTrackIndex ?: videoState?.audioTrackIndex
                 val subtitleTrackIndex = mediaItem.mediaMetadata.subtitleTrackIndex ?: videoState?.subtitleTrackIndex
@@ -709,7 +710,8 @@ class PlayerService : MediaSessionService() {
                             setArtworkUri(artworkUri)
                             setExtras(
                                 positionMs = positionMs,
-                                videoScale = videoScale,
+                                videoScaleX = videoScaleX,
+                                videoScaleY = videoScaleY,
                                 playbackSpeed = playbackSpeed,
                                 audioTrackIndex = audioTrackIndex,
                                 subtitleTrackIndex = subtitleTrackIndex,

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
@@ -523,15 +523,65 @@ class PlayerService : MediaSessionService() {
 
     override fun onCreate() {
         super.onCreate()
-        val renderersFactory = NextRenderersFactory(applicationContext)
-            .setEnableDecoderFallback(true)
-            .setExtensionRendererMode(
+        val renderersFactory = object : NextRenderersFactory(applicationContext) {
+            override fun getCodecAdapterFactory(): androidx.media3.exoplayer.mediacodec.MediaCodecAdapter.Factory {
+                val defaultFactory = super.getCodecAdapterFactory()
+                return androidx.media3.exoplayer.mediacodec.MediaCodecAdapter.Factory { configuration ->
+                    if (playerPreferences.dv7Fallback && androidx.media3.common.MimeTypes.VIDEO_DOLBY_VISION == configuration.format.sampleMimeType) {
+                        if (android.os.Build.VERSION.SDK_INT >= 29) {
+                            configuration.mediaFormat.removeKey(android.media.MediaFormat.KEY_PROFILE)
+                        } else {
+                            configuration.mediaFormat.setInteger(android.media.MediaFormat.KEY_PROFILE, android.media.MediaCodecInfo.CodecProfileLevel.HEVCProfileMain10)
+                        }
+                        if (android.os.Build.VERSION.SDK_INT >= 31) {
+                            configuration.mediaFormat.removeKey(android.media.MediaFormat.KEY_COLOR_TRANSFER_REQUEST)
+                        }
+                    }
+                    defaultFactory.createAdapter(configuration)
+                }
+            }
+
+            override fun buildVideoRenderers(
+                context: android.content.Context,
+                extensionRendererMode: Int,
+                mediaCodecSelector: androidx.media3.exoplayer.mediacodec.MediaCodecSelector,
+                enableDecoderFallback: Boolean,
+                eventHandler: android.os.Handler,
+                eventListener: androidx.media3.exoplayer.video.VideoRendererEventListener,
+                allowedVideoJoiningTimeMs: Long,
+                out: java.util.ArrayList<androidx.media3.exoplayer.Renderer>
+            ) {
+                val customSelector = androidx.media3.exoplayer.mediacodec.MediaCodecSelector { mimeType, requiresSecureDecoder, requiresTunnelingDecoder ->
+                    if (playerPreferences.dv7Fallback && androidx.media3.common.MimeTypes.VIDEO_DOLBY_VISION == mimeType) {
+                        androidx.media3.exoplayer.mediacodec.MediaCodecUtil.getDecoderInfos(
+                            androidx.media3.common.MimeTypes.VIDEO_H265, requiresSecureDecoder, requiresTunnelingDecoder
+                        )
+                    } else {
+                        mediaCodecSelector.getDecoderInfos(mimeType, requiresSecureDecoder, requiresTunnelingDecoder)
+                    }
+                }
+                
+                super.buildVideoRenderers(
+                    context,
+                    extensionRendererMode,
+                    customSelector,
+                    enableDecoderFallback,
+                    eventHandler,
+                    eventListener,
+                    allowedVideoJoiningTimeMs,
+                    out
+                )
+            }
+        }.apply {
+            setEnableDecoderFallback(true)
+            setExtensionRendererMode(
                 when (playerPreferences.decoderPriority) {
-                    DecoderPriority.DEVICE_ONLY -> DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF
-                    DecoderPriority.PREFER_DEVICE -> DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON
-                    DecoderPriority.PREFER_APP -> DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER
+                    DecoderPriority.DEVICE_ONLY -> androidx.media3.exoplayer.DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF
+                    DecoderPriority.PREFER_DEVICE -> androidx.media3.exoplayer.DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON
+                    DecoderPriority.PREFER_APP -> androidx.media3.exoplayer.DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER
                 },
             )
+        }
 
         val trackSelector = DefaultTrackSelector(applicationContext).apply {
             setParameters(

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/state/VideoZoomAndContentScaleState.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/state/VideoZoomAndContentScaleState.kt
@@ -20,6 +20,8 @@ import dev.anilbeesetti.nextplayer.core.model.VideoContentScale
 import dev.anilbeesetti.nextplayer.feature.player.extensions.copy
 import dev.anilbeesetti.nextplayer.feature.player.extensions.next
 import dev.anilbeesetti.nextplayer.feature.player.extensions.videoZoom
+import dev.anilbeesetti.nextplayer.feature.player.extensions.videoZoomX
+import dev.anilbeesetti.nextplayer.feature.player.extensions.videoZoomY
 import kotlin.math.abs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/state/VideoZoomAndContentScaleState.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/state/VideoZoomAndContentScaleState.kt
@@ -68,7 +68,10 @@ class VideoZoomAndContentScaleState(
     var videoContentScale: VideoContentScale by mutableStateOf(initialContentScale)
         private set
 
-    var zoom: Float by mutableFloatStateOf(1f)
+    var zoomX: Float by mutableFloatStateOf(1f)
+        private set
+
+    var zoomY: Float by mutableFloatStateOf(1f)
         private set
 
     var offset: Offset by mutableStateOf(Offset.Zero)
@@ -84,7 +87,8 @@ class VideoZoomAndContentScaleState(
 
     fun onVideoContentScaleChanged(newContentScale: VideoContentScale) {
         videoContentScale = newContentScale
-        zoom = 1f
+        zoomX = 1f
+        zoomY = 1f
         offset = Offset.Zero
         onEvent(VideoZoomEvent.ContentScaleChanged(videoContentScale))
         updateVideoScaleMetadataAndSendEvent()
@@ -105,23 +109,24 @@ class VideoZoomAndContentScaleState(
         onVideoContentScaleChanged(videoContentScale.next())
     }
 
-    fun onZoomPanGesture(constraints: Constraints, panChange: Offset, zoomChange: Float) {
+    fun onZoomPanGesture(constraints: Constraints, panChange: Offset, zoomChange: Offset) {
         if (player.duration == C.TIME_UNSET) return
         if (!enableZoomGesture) return
 
         isZooming = true
-        zoom = (zoom * zoomChange).coerceIn(MIN_ZOOM, MAX_ZOOM)
+        zoomX = (zoomX * zoomChange.x).coerceIn(MIN_ZOOM, MAX_ZOOM)
+        zoomY = (zoomY * zoomChange.y).coerceIn(MIN_ZOOM, MAX_ZOOM)
 
-        val extraWidth = (zoom - 1) * constraints.maxWidth
-        val extraHeight = (zoom - 1) * constraints.maxHeight
+        val extraWidth = (zoomX - 1) * constraints.maxWidth
+        val extraHeight = (zoomY - 1) * constraints.maxHeight
 
         val maxX = abs(extraWidth / 2)
         val maxY = abs(extraHeight / 2)
 
         if (enablePanGesture) {
             offset = Offset(
-                x = (offset.x + zoom * panChange.x).coerceIn(-maxX, maxX),
-                y = (offset.y + zoom * panChange.y).coerceIn(-maxY, maxY),
+                x = (offset.x + zoomX * panChange.x).coerceIn(-maxX, maxX),
+                y = (offset.y + zoomY * panChange.y).coerceIn(-maxY, maxY),
             )
         }
     }
@@ -132,25 +137,27 @@ class VideoZoomAndContentScaleState(
     }
 
     suspend fun observe() {
-        zoom = player.currentMediaItem?.mediaMetadata?.videoZoom ?: 1f
+        zoomX = player.currentMediaItem?.mediaMetadata?.videoZoomX ?: 1f
+        zoomY = player.currentMediaItem?.mediaMetadata?.videoZoomY ?: 1f
         player.listen { events ->
             if (events.contains(Player.EVENT_MEDIA_METADATA_CHANGED)) {
-                zoom = player.currentMediaItem?.mediaMetadata?.videoZoom ?: 1f
+                zoomX = player.currentMediaItem?.mediaMetadata?.videoZoomX ?: 1f
+                zoomY = player.currentMediaItem?.mediaMetadata?.videoZoomY ?: 1f
             }
         }
     }
 
-    private fun updateVideoScaleMetadataAndSendEvent(zoom: Float = this.zoom) {
+    private fun updateVideoScaleMetadataAndSendEvent(zoomX: Float = this.zoomX, zoomY: Float = this.zoomY) {
         val currentMediaItem = player.currentMediaItem ?: return
         player.replaceMediaItem(
             player.currentMediaItemIndex,
-            currentMediaItem.copy(videoZoom = zoom),
+            currentMediaItem.copy(videoZoomX = zoomX, videoZoomY = zoomY),
         )
-        onEvent(VideoZoomEvent.ZoomChanged(currentMediaItem, zoom))
+        onEvent(VideoZoomEvent.ZoomChanged(currentMediaItem, zoomX, zoomY))
     }
 }
 
 sealed interface VideoZoomEvent {
     data class ContentScaleChanged(val contentScale: VideoContentScale) : VideoZoomEvent
-    data class ZoomChanged(val mediaItem: MediaItem, val zoom: Float) : VideoZoomEvent
+    data class ZoomChanged(val mediaItem: MediaItem, val zoomX: Float, val zoomY: Float) : VideoZoomEvent
 }

--- a/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/decoder/DecoderPreferencesScreen.kt
+++ b/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/decoder/DecoderPreferencesScreen.kt
@@ -31,6 +31,7 @@ import dev.anilbeesetti.nextplayer.core.ui.components.ClickablePreferenceItem
 import dev.anilbeesetti.nextplayer.core.ui.components.ListSectionTitle
 import dev.anilbeesetti.nextplayer.core.ui.components.NextTopAppBar
 import dev.anilbeesetti.nextplayer.core.ui.components.RadioTextButton
+import dev.anilbeesetti.nextplayer.core.ui.components.PreferenceSwitch
 import dev.anilbeesetti.nextplayer.core.ui.designsystem.NextIcons
 import dev.anilbeesetti.nextplayer.core.ui.theme.NextPlayerTheme
 import dev.anilbeesetti.nextplayer.settings.composables.OptionsDialog
@@ -94,6 +95,13 @@ private fun DecoderPreferencesContent(
                     icon = NextIcons.Priority,
                     onClick = { onEvent(DecoderPreferencesUiEvent.ShowDialog(DecoderPreferenceDialog.DecoderPriorityDialog)) },
                     isFirstItem = true,
+                )
+                PreferenceSwitch(
+                    title = stringResource(id = R.string.dv7_fallback),
+                    description = stringResource(id = R.string.dv7_fallback_description),
+                    icon = NextIcons.Video,
+                    isChecked = preferences.dv7Fallback,
+                    onClick = { onEvent(DecoderPreferencesUiEvent.UpdateDv7Fallback(!preferences.dv7Fallback)) },
                     isLastItem = true,
                 )
             }

--- a/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/decoder/DecoderPreferencesViewModel.kt
+++ b/feature/settings/src/main/java/dev/anilbeesetti/nextplayer/settings/screens/decoder/DecoderPreferencesViewModel.kt
@@ -39,12 +39,21 @@ class DecoderPreferencesViewModel @Inject constructor(
         when (event) {
             is DecoderPreferencesUiEvent.ShowDialog -> showDialog(event.value)
             is DecoderPreferencesUiEvent.UpdateDecoderPriority -> updateDecoderPriority(event.value)
+            is DecoderPreferencesUiEvent.UpdateDv7Fallback -> updateDv7Fallback(event.value)
         }
     }
 
     private fun showDialog(value: DecoderPreferenceDialog?) {
         uiStateInternal.update {
             it.copy(showDialog = value)
+        }
+    }
+
+    private fun updateDv7Fallback(value: Boolean) {
+        viewModelScope.launch {
+            preferencesRepository.updatePlayerPreferences {
+                it.copy(dv7Fallback = value)
+            }
         }
     }
 
@@ -70,4 +79,5 @@ sealed interface DecoderPreferenceDialog {
 sealed interface DecoderPreferencesUiEvent {
     data class ShowDialog(val value: DecoderPreferenceDialog?) : DecoderPreferencesUiEvent
     data class UpdateDecoderPriority(val value: DecoderPriority) : DecoderPreferencesUiEvent
+    data class UpdateDv7Fallback(val value: Boolean) : DecoderPreferencesUiEvent
 }


### PR DESCRIPTION
**Describe the bug**
When the `dv7Fallback` preference is enabled, Exynos devices (e.g., Samsung A54/A55/A56) play audio but show a completely black screen for Dolby Vision Profile 7 videos. The Exynos hardware HEVC decoder silently drops frames instead of throwing a decoding exception when the `MediaFormat` contains `KEY_PROFILE = 128` (HEVCProfileMain10HDR10Plus/DV) and `KEY_COLOR_TRANSFER_REQUEST`. 

This issue does not exist in older ExoPlayer versions (e.g., JustPlayer) because they do not send `KEY_COLOR_TRANSFER_REQUEST`.

**Solution**
This PR fixes the issue by wrapping the `MediaCodecAdapter.Factory` inside `NextRenderersFactory`. 
When `dv7Fallback` is true and the stream is `VIDEO_DOLBY_VISION`, it aggressively strips `KEY_PROFILE` and `KEY_COLOR_TRANSFER_REQUEST` from the `MediaFormat` before creating the decoder. This forces the Exynos hardware decoder to treat it as a generic HEVC stream and successfully output HDR frames without silently dropping them.

**Testing**
Tested and confirmed working perfectly on Samsung A56 5G (Exynos chip).