### PR TITLE
Fix subtitles rendered outside the video in portrait mode

### DIFF
--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerContentFrame.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerContentFrame.kt
@@ -15,6 +15,7 @@ import androidx.media3.ui.compose.SURFACE_TYPE_SURFACE_VIEW
 import androidx.media3.ui.compose.modifiers.resizeWithContentScale
 import androidx.media3.ui.compose.state.rememberPresentationState
 import dev.anilbeesetti.nextplayer.feature.player.extensions.toContentScale
+import dev.anilbeesetti.nextplayer.feature.player.extensions.videoContentFrame
 import dev.anilbeesetti.nextplayer.feature.player.state.ControlsVisibilityState
 import dev.anilbeesetti.nextplayer.feature.player.state.PictureInPictureState
 import dev.anilbeesetti.nextplayer.feature.player.state.SeekGestureState
@@ -40,18 +41,20 @@ fun PlayerContentFrame(
     subtitleConfiguration: SubtitleConfiguration,
 ) {
     val presentationState = rememberPresentationState(player)
+    val contentScale = videoZoomAndContentScaleState.videoContentScale.toContentScale()
+    val sourceSizeDp = presentationState.videoSizeDp?.let { size ->
+        size.copy(
+            width = with(LocalDensity.current) { size.width.toDp().value },
+            height = with(LocalDensity.current) { size.height.toDp().value },
+        )
+    }
     PlayerSurface(
         player = player,
         surfaceType = SURFACE_TYPE_SURFACE_VIEW,
         modifier = modifier
             .resizeWithContentScale(
-                contentScale = videoZoomAndContentScaleState.videoContentScale.toContentScale(),
-                sourceSizeDp = presentationState.videoSizeDp?.let { size ->
-                    size.copy(
-                        width = with(LocalDensity.current) { size.width.toDp().value },
-                        height = with(LocalDensity.current) { size.height.toDp().value },
-                    )
-                },
+                contentScale = contentScale,
+                sourceSizeDp = sourceSizeDp,
             )
             .onGloballyPositioned {
                 val bounds = it.boundsInWindow()
@@ -81,6 +84,10 @@ fun PlayerContentFrame(
     )
 
     SubtitleView(
+        modifier = Modifier.videoContentFrame(
+            contentScale = contentScale,
+            videoSizeDp = sourceSizeDp,
+        ),
         player = player,
         isInPictureInPictureMode = pictureInPictureState.isInPictureInPictureMode,
         configuration = subtitleConfiguration,

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/Modifier.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/Modifier.kt
@@ -2,9 +2,17 @@ package dev.anilbeesetti.nextplayer.feature.player.extensions
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Dp
+import kotlin.math.min
+import kotlin.math.roundToInt
 
 @Composable
 fun Modifier.noRippleClickable(enabled: Boolean = true, onClick: () -> Unit): Modifier = clickable(
@@ -13,3 +21,41 @@ fun Modifier.noRippleClickable(enabled: Boolean = true, onClick: () -> Unit): Mo
     enabled = enabled,
     onClick = onClick,
 )
+
+/**
+ * Sizes the content to the visible video bounds rather than the entire player.
+ *
+ * Uses the same measurement behavior as [androidx.media3.ui.compose.modifiers.resizeWithContentScale],
+ * but clamps each axis to the player bounds so overlays match only the portion of the video visible on screen.
+ */
+internal fun Modifier.videoContentFrame(contentScale: ContentScale, videoSizeDp: Size?): Modifier = this
+    .fillMaxSize()
+    .wrapContentSize()
+    .layout { measurable, constraints ->
+        val frameSize = calculateVisibleVideoSize(
+            videoSize = videoSizeDp?.let { Size(Dp(it.width).toPx(), Dp(it.height).toPx()) },
+            containerSize = Size(constraints.maxWidth.toFloat(), constraints.maxHeight.toFloat()),
+            contentScale = contentScale,
+        )
+        val placeable = measurable.measure(
+            constraints.copy(
+                maxWidth = frameSize.width.roundToInt(),
+                maxHeight = frameSize.height.roundToInt(),
+            ),
+        )
+        layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+    }
+
+/**
+ * Falls back to [containerSize] until the video size is known,
+ * so that overlays do not jump when the first frame arrives.
+ */
+private fun calculateVisibleVideoSize(videoSize: Size?, containerSize: Size, contentScale: ContentScale): Size {
+    if (videoSize == null || videoSize.width <= 0f || videoSize.height <= 0f) return containerSize
+
+    val scaleFactor = contentScale.computeScaleFactor(videoSize, containerSize)
+    return Size(
+        width = min(videoSize.width * scaleFactor.scaleX, containerSize.width),
+        height = min(videoSize.height * scaleFactor.scaleY, containerSize.height),
+    )
+}


### PR DESCRIPTION
## Cause

`SubtitleView` uses `fillMaxSize()` as a sibling of `PlayerSurface`. As a result, it is measured against the entire player, while only the video surface is resized with `resizeWithContentScale`.

Media3 positions subtitle cues as a fraction of the subtitle view's height. For a letterboxed video, that fraction is therefore applied to the full screen rather than to the visible video area, causing subtitles to appear below the picture.

Cues with an embedded fractional size, such as SSA/ASS cues, are also scaled by the same incorrect ratio and become oversized. Plain SRT cues keep their expected size because the app applies an absolute text size.

The issue is primarily visible in portrait mode. In landscape, the video height usually matches the subtitle view height, so the incorrect measurement is not noticeable.

Media3's `PlayerView` avoids this by placing `SubtitleView` inside `exo_content_frame` in `exo_player_view.xml`.

## Fix

Measure the subtitle view against the visible video bounds instead of the entire player.

The calculated size uses the same `ContentScale` behavior as the video surface, but is clamped to the player bounds on each axis.

The clamp is required because `resizeWithContentScale` allows content to overflow the container. That behavior is correct for the video surface, but not for subtitles.

Without the clamp, `CROP` produced a subtitle view 4693 px wide on a 1080 px screen, causing both ends of the cue to render off-screen. `HUNDRED_PERCENT` can overflow horizontally as well, so the clamp must be applied independently to both axes.

Zoom, pan, and the Picture-in-Picture source rect remain applied only to the video surface. Subtitles therefore do not scale with pinch zoom, which preserves the existing behavior.

### Before / after

Portrait mode, embedded ASS subtitles.

| Before | After |
| ------ | ----- |
|  <img width="1080" height="2640" alt="2_portrait_ass" src="https://github.com/user-attachments/assets/c641bb09-26fe-4ae7-8000-a44cdfa5492c" /> |  <img width="1080" height="2640" alt="2_portrait_ass" src="https://github.com/user-attachments/assets/f180572d-352c-4f99-bfb5-8292ddf941f8" /> |