### PR TITLE
fix(player): restore super.onConnect for watch next/prev controls

### DIFF
--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
@@ -464,9 +464,7 @@ class PlayerService : MediaSessionService() {
             session: MediaSession,
             controller: MediaSession.ControllerInfo,
         ): MediaSession.ConnectionResult {
-            val connectionResult = MediaSession.ConnectionResult
-                .AcceptedResultBuilder(session, controller)
-                .build()
+            val connectionResult = super.onConnect(session, controller)
             return MediaSession.ConnectionResult.accept(
                 connectionResult.availableSessionCommands
                     .buildUpon()


### PR DESCRIPTION
Fixes #1881.

Regression 0.17.4 → 0.17.5 by aba7f6e6 (Fix Media3 session command defaults). Bare AcceptedResultBuilder dropped player-aware availablePlayerCommands, greying out Next and hiding Previous on external controllers (Wear OS / notification) while in-app phone controls kept working via direct player.seekToNext().

Change: restore super.onConnect(session, controller) in PlayerService onConnect, keeping customCommands merge.

Verification:
- ./gradlew :feature:player:test (16 PASSED)
- ./gradlew ktlintCheck (pass)
- ./gradlew assembleDebug (BUILD SUCCESSFUL)
- Manual: Pixel 3a API 34 notification controls