### PR TITLE
Add delete FAB in videopicker selection mode

### DIFF
--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerScreen.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.FloatingActionButtonMenu
 import androidx.compose.material3.FloatingActionButtonMenuItem
 import androidx.compose.material3.Icon
@@ -199,6 +200,15 @@ internal fun MediaPickerScreen(
 
     val selectedItemsSize = selectionManager.selectionItems.size
     val totalItemsSize = (uiState.mediaDataState as? DataState.Success)?.value?.run { folders.size + videos.size } ?: 0
+    val isDeleteFabVisible = selectionManager.isInSelectionMode && selectionManager.selectionItems.isNotEmpty()
+    val onDeleteSelected: () -> Unit = {
+        if (MediaOperationsService.willSystemAsksForDeleteConfirmation()) {
+            onAction(MediaPickerAction.DeleteSelectedItems(selectionManager.selectionItems))
+            selectionManager.exitSelectionMode()
+        } else {
+            showDeleteVideosConfirmation = true
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -322,6 +332,8 @@ internal fun MediaPickerScreen(
                 show = selectionManager.isInSelectionMode && selectionManager.selectionItems.isNotEmpty(),
                 firstActionFocusRequester = firstActionFocusRequester,
                 lastItemFocusRequester = lastItemFocusRequester,
+                fabFocusRequester = fabFocusRequester,
+                isDeleteFabVisible = isDeleteFabVisible,
                 showRenameAction = selectionManager.isSingleVideoSelected,
                 showInfoAction = selectionManager.isSingleVideoSelected,
                 showHideAction = selectionManager.selectionItems.isNotEmpty(),
@@ -360,18 +372,35 @@ internal fun MediaPickerScreen(
                     onAction(MediaPickerAction.RequestHideSelectedItems(selectionManager.selectionItems))
                     selectionManager.exitSelectionMode()
                 },
-                onDeleteAction = {
-                    if (MediaOperationsService.willSystemAsksForDeleteConfirmation()) {
-                        onAction(MediaPickerAction.DeleteSelectedItems(selectionManager.selectionItems))
-                        selectionManager.exitSelectionMode()
-                    } else {
-                        showDeleteVideosConfirmation = true
-                    }
-                },
+                onDeleteAction = onDeleteSelected,
             )
         },
         floatingActionButton = {
-            if (selectionManager.isInSelectionMode) return@Scaffold
+            if (isDeleteFabVisible) {
+                FloatingActionButton(
+                    onClick = onDeleteSelected,
+                    modifier = Modifier
+                        .tvFocusRing(
+                            isTv = isTv,
+                            shape = RoundedCornerShape(16.dp),
+                        )
+                        .thenIf(isTv && hasMedia) {
+                            focusRequester(fabFocusRequester)
+                                .focusProperties {
+                                    up = lastItemFocusRequester
+                                    down = firstActionFocusRequester
+                                }
+                        },
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                ) {
+                    Icon(
+                        imageVector = NextIcons.Delete,
+                        contentDescription = stringResource(id = R.string.delete),
+                    )
+                }
+            } else {
+                if (selectionManager.isInSelectionMode) return@Scaffold
 
             FloatingActionButtonMenu(
                 expanded = isFabExpanded,
@@ -464,6 +493,7 @@ internal fun MediaPickerScreen(
                     )
                 }
             }
+            }
         },
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
     ) { scaffoldPadding ->
@@ -519,10 +549,11 @@ internal fun MediaPickerScreen(
                             lastItemFocusRequester = if (isTv) lastItemFocusRequester else null,
                             restoredFocusKey = restoredFocusKey,
                             onItemFocused = { restoredFocusKey = it },
-                            // Down from the last item goes to the FAB normally, or to the selection
-                            // action bar while selecting (the FAB is hidden then).
+                            // Down from the last item goes to the FAB normally, to the delete FAB
+                            // when selecting, else to the selection action bar.
                             lastItemDownFocusRequester = when {
                                 !isTv -> null
+                                isDeleteFabVisible -> fabFocusRequester
                                 selectionManager.isInSelectionMode -> firstActionFocusRequester
                                 else -> fabFocusRequester
                             },
@@ -1212,6 +1243,8 @@ private fun SelectionActionsSheet(
     show: Boolean,
     firstActionFocusRequester: FocusRequester,
     lastItemFocusRequester: FocusRequester,
+    fabFocusRequester: FocusRequester,
+    isDeleteFabVisible: Boolean,
     showRenameAction: Boolean,
     showInfoAction: Boolean,
     showHideAction: Boolean,
@@ -1227,9 +1260,9 @@ private fun SelectionActionsSheet(
 ) {
     val context = LocalContext.current
     val isTv = remember { context.isTelevision }
-    // Pressing up from any action lands on the last list item.
+    // Pressing up from any action lands on the delete FAB when visible, else on the last list item.
     val actionUpModifier = if (isTv) {
-        Modifier.focusProperties { up = lastItemFocusRequester }
+        Modifier.focusProperties { up = if (isDeleteFabVisible) fabFocusRequester else lastItemFocusRequester }
     } else {
         Modifier
     }

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -393,6 +394,8 @@ private fun VaultGalleryScreen(
     val isTv = remember { context.isTelevision }
     val firstActionFocusRequester = remember { FocusRequester() }
     val firstItemRequester = remember { FocusRequester() }
+    val lastItemFocusRequester = remember { FocusRequester() }
+    val fabFocusRequester = remember { FocusRequester() }
     val restoreRequester = remember { FocusRequester() }
     var restoredFocusKey by rememberSaveable { mutableStateOf<String?>(null) }
     val selectionManager = rememberSelectionManager()
@@ -402,6 +405,7 @@ private fun VaultGalleryScreen(
 
     val selectedCount = selectionManager.selectionItems.size
     val totalCount = uiState.hiddenVideos.size
+    val isDeleteFabVisible = selectionManager.isInSelectionMode && selectionManager.selectionItems.isNotEmpty()
 
     var hasRequestedInitialFocus by remember { mutableStateOf(false) }
     if (isTv) {
@@ -502,6 +506,9 @@ private fun VaultGalleryScreen(
             VaultSelectionActionsSheet(
                 show = selectionManager.isInSelectionMode && selectionManager.selectionItems.isNotEmpty(),
                 firstActionFocusRequester = firstActionFocusRequester,
+                lastItemFocusRequester = lastItemFocusRequester,
+                fabFocusRequester = fabFocusRequester,
+                isDeleteFabVisible = isDeleteFabVisible,
                 onPlayAction = {
                     onAction(VaultAction.PlaySelected(selectionManager.selectionItems))
                     selectionManager.exitSelectionMode()
@@ -516,6 +523,32 @@ private fun VaultGalleryScreen(
                 onUnhideAction = { showUnhideConfirmation = true },
                 onDeleteAction = { showDeleteConfirmation = true },
             )
+        },
+        floatingActionButton = {
+            if (isDeleteFabVisible) {
+                FloatingActionButton(
+                    onClick = { showDeleteConfirmation = true },
+                    modifier = Modifier
+                        .tvFocusRing(
+                            isTv = isTv,
+                            shape = RoundedCornerShape(16.dp),
+                        )
+                        .thenIf(isTv) {
+                            focusRequester(fabFocusRequester)
+                                .focusProperties {
+                                    up = lastItemFocusRequester
+                                    down = firstActionFocusRequester
+                                }
+                        },
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                ) {
+                    Icon(
+                        imageVector = NextIcons.Delete,
+                        contentDescription = stringResource(R.string.delete),
+                    )
+                }
+            }
         },
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
     ) { padding ->
@@ -566,12 +599,22 @@ private fun VaultGalleryScreen(
                                 modifier = Modifier
                                     .padding(2.dp)
                                     .thenIf(isTv && index == 0) { focusRequester(firstItemRequester) }
-                                    // Down from the last item reaches the selection action bar.
+                                    .thenIf(isTv && index == uiState.hiddenVideos.lastIndex) {
+                                        focusRequester(lastItemFocusRequester)
+                                    }
+                                    // Down from the last item reaches the delete FAB when visible,
+                                    // else the selection action bar.
                                     .thenIf(
                                         isTv && selectionManager.isInSelectionMode &&
                                             index == uiState.hiddenVideos.lastIndex,
                                     ) {
-                                        focusProperties { down = firstActionFocusRequester }
+                                        focusProperties {
+                                            down = if (isDeleteFabVisible) {
+                                                fabFocusRequester
+                                            } else {
+                                                firstActionFocusRequester
+                                            }
+                                        }
                                     }
                                     .restorableFocusItem(
                                         isTv = isTv,
@@ -786,6 +829,9 @@ private fun VaultSelectionActionsSheet(
     modifier: Modifier = Modifier,
     show: Boolean,
     firstActionFocusRequester: FocusRequester,
+    lastItemFocusRequester: FocusRequester,
+    fabFocusRequester: FocusRequester,
+    isDeleteFabVisible: Boolean,
     onPlayAction: () -> Unit,
     onInfoAction: () -> Unit,
     showInfoAction: Boolean,
@@ -794,6 +840,12 @@ private fun VaultSelectionActionsSheet(
 ) {
     val context = LocalContext.current
     val isTv = remember { context.isTelevision }
+    val actionsUpTarget = if (isDeleteFabVisible) fabFocusRequester else lastItemFocusRequester
+    val actionUpModifier = if (isTv) {
+        Modifier.focusProperties { up = actionsUpTarget }
+    } else {
+        Modifier
+    }
 
     AnimatedVisibility(
         modifier = modifier.padding(
@@ -828,7 +880,7 @@ private fun VaultSelectionActionsSheet(
                 horizontalArrangement = Arrangement.SpaceEvenly,
             ) {
                 VaultSelectionAction(
-                    modifier = Modifier.focusRequester(firstActionFocusRequester),
+                    modifier = Modifier.focusRequester(firstActionFocusRequester).then(actionUpModifier),
                     isTv = isTv,
                     imageVector = NextIcons.Play,
                     title = stringResource(R.string.play),
@@ -836,6 +888,7 @@ private fun VaultSelectionActionsSheet(
                 )
                 if (showInfoAction) {
                     VaultSelectionAction(
+                        modifier = actionUpModifier,
                         isTv = isTv,
                         imageVector = NextIcons.Info,
                         title = stringResource(R.string.info),
@@ -843,12 +896,14 @@ private fun VaultSelectionActionsSheet(
                     )
                 }
                 VaultSelectionAction(
+                    modifier = actionUpModifier,
                     isTv = isTv,
                     imageVector = NextIcons.Lock,
                     title = stringResource(R.string.unhide),
                     onClick = onUnhideAction,
                 )
                 VaultSelectionAction(
+                    modifier = actionUpModifier,
                     isTv = isTv,
                     imageVector = NextIcons.Delete,
                     title = stringResource(R.string.delete),


### PR DESCRIPTION
Problem: in folder/video selection mode the Delete action sits at the far end of the horizontally scrollable bottom action sheet, so users must scroll to reach it.

Solution: show a tonal Delete FAB in the same bottom-corner position as the normal Play FAB whenever selection mode has at least one item selected. It reuses the exact delete flow as the bottom-bar Delete (including system delete confirmation vs in-app confirmation dialog). Bottom-bar Delete is kept unchanged. Applied to both MediaPicker and Vault gallery for consistency, with TV D-pad focus chain list <-> FAB <-> action sheet.

Verification:
- ./gradlew ktlintCheck assembleDebug — BUILD SUCCESSFUL
- ./gradlew test — BUILD SUCCESSFUL
- Manual: Pixel_3a_API_34 emulator, AISDKv6 folder — long-press video, Delete FAB appears bottom-end, tap triggers same delete confirmation; clearing selection restores Play FAB. Same flow checked in Vault.