### PR TITLE
Simplify vault code and add opt-in biometric unlock

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -146,6 +146,7 @@ dependencies {
     testImplementation(libs.robolectric)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.test.ext)
+    androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.test.espresso.core)
     androidTestImplementation(libs.androidx.compose.ui.test)
     debugImplementation(libs.androidx.compose.ui.tooling)

--- a/app/src/androidTest/java/dev/anilbeesetti/nextplayer/MainActivityNavigationTest.kt
+++ b/app/src/androidTest/java/dev/anilbeesetti/nextplayer/MainActivityNavigationTest.kt
@@ -1,0 +1,63 @@
+package dev.anilbeesetti.nextplayer
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import dev.anilbeesetti.nextplayer.core.common.storagePermission
+import dev.anilbeesetti.nextplayer.core.ui.R
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityNavigationTest {
+    @get:Rule(order = 0)
+    val permissionRule: GrantPermissionRule = GrantPermissionRule.grant(storagePermission)
+
+    @get:Rule(order = 1)
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun settingsOpensAfterActivityRecreation() {
+        recreateHome()
+        val settings = composeRule.activity.getString(R.string.settings)
+
+        composeRule.onNodeWithContentDescription(settings).performClick()
+
+        composeRule.onNodeWithText(settings).assertIsDisplayed()
+    }
+
+    @Test
+    fun vaultOpensAfterActivityRecreation() {
+        recreateHome()
+        val appName = composeRule.activity.getString(R.string.app_name)
+        val enterPin = composeRule.activity.getString(R.string.enter_vault_pin)
+        val setPin = composeRule.activity.getString(R.string.set_vault_pin)
+
+        composeRule.onNodeWithText(appName).performTouchInput { longClick() }
+
+        composeRule.waitUntil(10_000) {
+            composeRule.onAllNodesWithText(enterPin).fetchSemanticsNodes().isNotEmpty() ||
+                composeRule.onAllNodesWithText(setPin).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun recreateHome() {
+        val settings = composeRule.activity.getString(R.string.settings)
+        composeRule.waitUntil(10_000) {
+            composeRule.onAllNodesWithContentDescription(settings).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeRule.activityRule.scenario.recreate()
+        composeRule.waitUntil(10_000) {
+            composeRule.onAllNodesWithContentDescription(settings).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+}

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/MainActivity.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/MainActivity.kt
@@ -2,7 +2,6 @@ package dev.anilbeesetti.nextplayer
 
 import android.graphics.Color
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -25,6 +24,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -48,11 +48,11 @@ import dev.anilbeesetti.nextplayer.navigation.playlistNavGraph
 import dev.anilbeesetti.nextplayer.navigation.rememberResponsiveNavigationSceneDecoratorStrategy
 import dev.anilbeesetti.nextplayer.navigation.rememberTopLevelNavState
 import dev.anilbeesetti.nextplayer.navigation.settingsNavGraph
-import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class MainActivity : ComponentActivity() {
+class MainActivity : FragmentActivity() {
 
     @Inject
     lateinit var mediaOperationsService: MediaOperationsService

--- a/core/data/src/androidTest/AndroidManifest.xml
+++ b/core/data/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/vault_test_paths" />
+        </provider>
+    </application>
+</manifest>

--- a/core/data/src/androidTest/res/xml/vault_test_paths.xml
+++ b/core/data/src/androidTest/res/xml/vault_test_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path name="vault" path="vault/" />
+    <external-files-path name="external_vault" path="vault/" />
+</paths>

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultPinRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultPinRepository.kt
@@ -1,6 +1,7 @@
 package dev.anilbeesetti.nextplayer.core.data.repository
 
 import android.content.Context
+import androidx.core.content.edit
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.security.MessageDigest
 import java.security.SecureRandom
@@ -8,7 +9,6 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import androidx.core.content.edit
 
 @Singleton
 class LocalVaultPinRepository @Inject constructor(
@@ -28,6 +28,7 @@ class LocalVaultPinRepository @Inject constructor(
         preferences.edit {
             putString(KEY_PIN_HASH, hashPin(pin, salt))
             putString(KEY_SALT, salt)
+            putBoolean(KEY_BIOMETRIC_ENABLED, false)
         }
     }
 
@@ -39,6 +40,14 @@ class LocalVaultPinRepository @Inject constructor(
 
     override suspend fun hasShownHideConfirmation(): Boolean = withContext(Dispatchers.IO) {
         preferences.getBoolean(KEY_HIDE_CONFIRMATION_SHOWN, false)
+    }
+
+    override suspend fun isBiometricEnabled(): Boolean = withContext(Dispatchers.IO) {
+        preferences.getBoolean(KEY_BIOMETRIC_ENABLED, false)
+    }
+
+    override suspend fun setBiometricEnabled(enabled: Boolean) = withContext(Dispatchers.IO) {
+        preferences.edit { putBoolean(KEY_BIOMETRIC_ENABLED, enabled) }
     }
 
     override suspend fun setHideConfirmationShown() = withContext(Dispatchers.IO) {
@@ -63,6 +72,7 @@ class LocalVaultPinRepository @Inject constructor(
         private const val PREFS_NAME = "vault_security_prefs"
         private const val KEY_PIN_HASH = "vault_pin_hash"
         private const val KEY_SALT = "vault_pin_salt"
+        private const val KEY_BIOMETRIC_ENABLED = "vault_biometric_enabled"
         private const val KEY_HIDE_CONFIRMATION_SHOWN = "vault_hide_confirmation_shown"
     }
 }

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepository.kt
@@ -55,24 +55,23 @@ class LocalVaultRepository @Inject constructor(
     override fun observeHiddenVideos(): Flow<List<Video>> {
         return combine(hiddenVideoDao.getAll(), pendingVaultPaths) { entities, pendingPaths ->
             entities
-                .filterNot { it.vaultPath in pendingPaths }
-                .filter { File(it.vaultPath).exists() }
+                .filter { it.vaultPath !in pendingPaths && File(it.vaultPath).exists() }
                 .map { it.toVideo() }
         }
     }
 
-    override suspend fun hideVideos(videos: List<Video>) = vaultMutationMutex.withLock {
-        hideVideosLocked(videos)
-    }
-
-    private suspend fun hideVideosLocked(videos: List<Video>) {
+    override suspend fun hideVideos(videos: List<Video>): Unit = vaultMutationMutex.withLock {
         val reservations = reserveVideos(videos)
-        if (reservations.isEmpty()) return
+        if (reservations.isEmpty()) return@withLock
 
         try {
-            val moveOutcome = moveReservedVideos(reservations)
-            reconcileReservations(reservations, moveOutcome)
-            moveOutcome.rethrowCancellation()
+            val moveResult = try {
+                Result.success(mediaOperationsService.moveMedia(reservations.associate { it.sourceUri to it.destination }))
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+            reconcileReservations(reservations, moveResult)
+            moveResult.exceptionOrNull()?.let { if (it is CancellationException) throw it }
         } finally {
             revealReservations(reservations.map { it.destination.absolutePath })
         }
@@ -82,36 +81,23 @@ class LocalVaultRepository @Inject constructor(
         val attemptedVaultPaths = mutableListOf<String>()
         return try {
             videos.mapNotNull { video ->
-                reserveVideo(video, attemptedVaultPaths)
+                val destination = createVaultDestination(video.nameWithExtension)
+                attemptedVaultPaths += destination.absolutePath
+                pendingVaultPaths.update { it + destination.absolutePath }
+                val rowId = try {
+                    hiddenVideoDao.insert(video.toHiddenVideoEntity(destination))
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    cleanUpReservations(listOf(destination.absolutePath))
+                    return@mapNotNull null
+                }
+                HideReservation(rowId, video.uriString.toUri(), destination)
             }
         } catch (e: Exception) {
             cleanUpReservations(attemptedVaultPaths)
             throw e
         }
-    }
-
-    private suspend fun reserveVideo(
-        video: Video,
-        attemptedVaultPaths: MutableList<String>,
-    ): HideReservation? {
-        val destination = createVaultDestination(video.nameWithExtension)
-        attemptedVaultPaths += destination.absolutePath
-        val sourceUri = video.uriString.toUri()
-        val entity = video.toHiddenVideoEntity(destination)
-        pendingVaultPaths.update { it + destination.absolutePath }
-        val rowId = try {
-            hiddenVideoDao.insert(entity)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            cleanUpReservations(listOf(destination.absolutePath))
-            return null
-        }
-        return HideReservation(
-            rowId = rowId,
-            sourceUri = sourceUri,
-            destination = destination,
-        )
     }
 
     private fun Video.toHiddenVideoEntity(destination: File): HiddenVideoEntity {
@@ -133,28 +119,6 @@ class LocalVaultRepository @Inject constructor(
         val destination: File,
     )
 
-    private sealed interface MoveOutcome {
-        data class Completed(val movedFiles: Map<Uri, File?>) : MoveOutcome
-        data object Failed : MoveOutcome
-        data class Cancelled(val exception: CancellationException) : MoveOutcome
-    }
-
-    private suspend fun moveReservedVideos(
-        reservations: List<HideReservation>,
-    ): MoveOutcome {
-        return try {
-            MoveOutcome.Completed(
-                mediaOperationsService.moveMedia(
-                    reservations.associate { it.sourceUri to it.destination },
-                ),
-            )
-        } catch (e: CancellationException) {
-            MoveOutcome.Cancelled(e)
-        } catch (e: Exception) {
-            MoveOutcome.Failed
-        }
-    }
-
     private fun createVaultDestination(displayName: String): File {
         val extension = File(displayName).extension.takeIf { it.isNotBlank() }
         val suffix = extension?.let { ".$it" }.orEmpty()
@@ -164,10 +128,14 @@ class LocalVaultRepository @Inject constructor(
 
     private suspend fun reconcileReservations(
         reservations: List<HideReservation>,
-        moveOutcome: MoveOutcome,
+        moveResult: Result<Map<Uri, File?>>,
     ) {
+        val movedFiles = moveResult.getOrNull()
         val failedRowIds = reservations.mapNotNull { reservation ->
-            reservation.rowId.takeUnless { moveOutcome.wasCommitted(reservation) }
+            // If moving threw, the destination is the only evidence that a move committed.
+            val committed = reservation.destination.exists() &&
+                (movedFiles == null || movedFiles[reservation.sourceUri] == reservation.destination)
+            reservation.rowId.takeUnless { committed }
         }
         if (failedRowIds.isEmpty()) return
         withContext(NonCancellable) {
@@ -176,30 +144,12 @@ class LocalVaultRepository @Inject constructor(
         }
     }
 
-    private fun MoveOutcome.wasCommitted(reservation: HideReservation): Boolean {
-        return when (this) {
-            is MoveOutcome.Completed -> {
-                movedFiles[reservation.sourceUri] == reservation.destination &&
-                    reservation.destination.exists()
-            }
-            MoveOutcome.Failed, is MoveOutcome.Cancelled -> reservation.destination.exists()
-        }
-    }
-
-    private fun MoveOutcome.rethrowCancellation() {
-        if (this is MoveOutcome.Cancelled) throw exception
-    }
-
-    private suspend fun deleteReservationsByVaultPath(vaultPaths: List<String>) {
+    private suspend fun cleanUpReservations(vaultPaths: List<String>) {
         if (vaultPaths.isEmpty()) return
         withContext(NonCancellable) {
             runCatching { hiddenVideoDao.deleteByVaultPaths(vaultPaths) }
                 .onFailure { logCleanupFailure("delete reservations by vault path", it) }
         }
-    }
-
-    private suspend fun cleanUpReservations(vaultPaths: List<String>) {
-        deleteReservationsByVaultPath(vaultPaths)
         revealReservations(vaultPaths)
     }
 

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/VaultPinRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/VaultPinRepository.kt
@@ -1,7 +1,7 @@
 package dev.anilbeesetti.nextplayer.core.data.repository
 
 /**
- * Manages the 4-digit PIN that protects the vault.
+ * Manages the vault PIN and biometric unlock preference.
  */
 interface VaultPinRepository {
 
@@ -19,6 +19,11 @@ interface VaultPinRepository {
      * Returns `true` if [pin] matches the currently stored vault PIN.
      */
     suspend fun verifyPin(pin: String): Boolean
+
+    /** Whether the user has enabled biometric unlock after confirming with a biometric scan. */
+    suspend fun isBiometricEnabled(): Boolean
+
+    suspend fun setBiometricEnabled(enabled: Boolean)
 
     /**
      * Whether the one-time "hide this video?" confirmation dialog has already been shown to

--- a/core/data/src/test/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultPinRepositoryTest.kt
+++ b/core/data/src/test/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultPinRepositoryTest.kt
@@ -1,0 +1,52 @@
+package dev.anilbeesetti.nextplayer.core.data.repository
+
+import android.content.Context
+import androidx.core.content.edit
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class LocalVaultPinRepositoryTest {
+    private val context = RuntimeEnvironment.getApplication()
+    private val repository = LocalVaultPinRepository(context)
+
+    @Test
+    fun `biometrics default to disabled for existing vaults`() = runTest {
+        context.getSharedPreferences("vault_security_prefs", Context.MODE_PRIVATE).edit {
+            putString("vault_pin_hash", "existing hash")
+        }
+
+        assertTrue(repository.hasPinSet())
+        assertFalse(repository.isBiometricEnabled())
+    }
+
+    @Test
+    fun `biometric choice persists across repository instances`() = runTest {
+        repository.setPin("1234")
+        repository.setBiometricEnabled(true)
+        val reopened = LocalVaultPinRepository(context)
+        assertTrue(reopened.isBiometricEnabled())
+
+        reopened.setBiometricEnabled(false)
+
+        assertFalse(LocalVaultPinRepository(context).isBiometricEnabled())
+        assertTrue(repository.verifyPin("1234"))
+    }
+
+    @Test
+    fun `setting a new PIN requires a new biometric opt in`() = runTest {
+        repository.setPin("1234")
+        assertFalse(repository.isBiometricEnabled())
+        repository.setBiometricEnabled(true)
+
+        repository.setPin("5678")
+
+        assertFalse(repository.isBiometricEnabled())
+        assertTrue(repository.verifyPin("5678"))
+    }
+}

--- a/core/ui/src/main/java/dev/anilbeesetti/nextplayer/core/ui/designsystem/NextIcons.kt
+++ b/core/ui/src/main/java/dev/anilbeesetti/nextplayer/core/ui/designsystem/NextIcons.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.CheckCircle
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.ClosedCaption
+import androidx.compose.material.icons.rounded.Cloud
 import androidx.compose.material.icons.rounded.ContentCopy
 import androidx.compose.material.icons.rounded.Contrast
 import androidx.compose.material.icons.rounded.DarkMode
@@ -28,6 +29,7 @@ import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.DeleteSweep
 import androidx.compose.material.icons.rounded.Deselect
 import androidx.compose.material.icons.rounded.DeveloperBoard
+import androidx.compose.material.icons.rounded.Dns
 import androidx.compose.material.icons.rounded.DoneAll
 import androidx.compose.material.icons.rounded.DoubleArrow
 import androidx.compose.material.icons.rounded.DragHandle
@@ -35,6 +37,7 @@ import androidx.compose.material.icons.rounded.Edit
 import androidx.compose.material.icons.rounded.FastForward
 import androidx.compose.material.icons.rounded.FileOpen
 import androidx.compose.material.icons.rounded.FilterFrames
+import androidx.compose.material.icons.rounded.Fingerprint
 import androidx.compose.material.icons.rounded.FlipToBack
 import androidx.compose.material.icons.rounded.Folder
 import androidx.compose.material.icons.rounded.FolderOff
@@ -46,18 +49,15 @@ import androidx.compose.material.icons.rounded.HeadsetOff
 import androidx.compose.material.icons.rounded.HideSource
 import androidx.compose.material.icons.rounded.History
 import androidx.compose.material.icons.rounded.Home
+import androidx.compose.material.icons.rounded.Image
 import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.Lan
-import androidx.compose.material.icons.rounded.Cloud
-import androidx.compose.material.icons.rounded.Dns
-import androidx.compose.material.icons.rounded.Storage
 import androidx.compose.material.icons.rounded.Link
 import androidx.compose.material.icons.rounded.LocalMovies
 import androidx.compose.material.icons.rounded.LocationOn
+import androidx.compose.material.icons.rounded.Lock
 import androidx.compose.material.icons.rounded.MiscellaneousServices
 import androidx.compose.material.icons.rounded.MoreVert
-import androidx.compose.material.icons.rounded.Image
-import androidx.compose.material.icons.rounded.Lock
 import androidx.compose.material.icons.rounded.Movie
 import androidx.compose.material.icons.rounded.Palette
 import androidx.compose.material.icons.rounded.PanToolAlt
@@ -76,6 +76,7 @@ import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Share
 import androidx.compose.material.icons.rounded.SmartButton
 import androidx.compose.material.icons.rounded.Speed
+import androidx.compose.material.icons.rounded.Storage
 import androidx.compose.material.icons.rounded.Straighten
 import androidx.compose.material.icons.rounded.Style
 import androidx.compose.material.icons.rounded.Subtitles
@@ -176,6 +177,7 @@ object NextIcons {
     val Image = Icons.Rounded.Image
     val Frame = Icons.Rounded.FilterFrames
     val Lock = Icons.Rounded.Lock
+    val Fingerprint = Icons.Rounded.Fingerprint
     val DragHandle = Icons.Rounded.DragHandle
     val Reorder = Icons.Rounded.SwapVert
 }

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -344,6 +344,13 @@
     <string name="open_vault">Open vault</string>
     <string name="unlock_with_biometrics">Unlock with biometrics</string>
     <string name="use_vault_pin">Use vault PIN</string>
+    <string name="vault_biometric_setup_title">Use biometrics to unlock?</string>
+    <string name="vault_biometric_setup_description">Unlock your vault with your fingerprint or face. Confirm with a biometric scan to enable it. You can still use your PIN and turn this off in Vault settings.</string>
+    <string name="enable_biometric_unlock">Enable biometric unlock</string>
+    <string name="not_now">Not now</string>
+    <string name="vault_settings">Vault settings</string>
+    <string name="vault_biometric_description">Use your fingerprint or face to unlock. Your vault PIN remains available.</string>
+    <string name="vault_biometric_unavailable">Set up a supported fingerprint or face in your device settings to enable biometric unlock.</string>
     <string name="vault_empty_title">No hidden videos</string>
     <string name="vault_empty_description">Videos you hide will show up here. Long press a video and tap Hide to add it to the vault.</string>
     <string name="unhide_one_video_confirmation">Unhide this video? It will be moved back to its original location.</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -342,6 +342,8 @@
     <string name="how_to_find_hidden_videos_description">Hidden videos are kept safe in your Vault. To open it again, press and hold the \"NextPlayer\" title at the top of the home screen and enter your PIN.</string>
     <string name="got_it">Got it</string>
     <string name="open_vault">Open vault</string>
+    <string name="unlock_with_biometrics">Unlock with biometrics</string>
+    <string name="use_vault_pin">Use vault PIN</string>
     <string name="vault_empty_title">No hidden videos</string>
     <string name="vault_empty_description">Videos you hide will show up here. Long press a video and tap Hide to add it to the vault.</string>
     <string name="unhide_one_video_confirmation">Unhide this video? It will be moved back to its original location.</string>

--- a/feature/videopicker/build.gradle.kts
+++ b/feature/videopicker/build.gradle.kts
@@ -47,9 +47,11 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.biometric)
     implementation(libs.google.android.material)
 
     // Compose
+    implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.tooling.preview)

--- a/feature/videopicker/src/main/AndroidManifest.xml
+++ b/feature/videopicker/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 </manifest>

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/SelectionAction.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/SelectionAction.kt
@@ -1,0 +1,61 @@
+package dev.anilbeesetti.nextplayer.feature.videopicker.composables
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import dev.anilbeesetti.nextplayer.core.ui.components.tvFocusRing
+
+@Composable
+internal fun SelectionAction(
+    imageVector: ImageVector,
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isTv: Boolean = false,
+) {
+    Column(
+        modifier = modifier
+            .defaultMinSize(
+                minWidth = 75.dp,
+                minHeight = 64.dp,
+            )
+            .tvFocusRing(isTv, shape = RoundedCornerShape(12.dp))
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(
+                horizontal = 16.dp,
+                vertical = 8.dp,
+            ),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            imageVector = imageVector,
+            contentDescription = title,
+            modifier = Modifier.size(24.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.size(4.dp))
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/vault/PinPad.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/vault/PinPad.kt
@@ -40,7 +40,7 @@ import dev.anilbeesetti.nextplayer.core.ui.components.tvFocusRing
 import dev.anilbeesetti.nextplayer.feature.videopicker.screens.vault.VAULT_PIN_LENGTH
 
 /**
- * Row of dots indicating how many PIN digits have been entered so far, out of [length].
+ * Row of dots indicating how many PIN digits have been entered so far, out of [VAULT_PIN_LENGTH].
  * Shakes briefly when [error] becomes true (e.g. wrong PIN, mismatched confirmation).
  */
 @Composable
@@ -48,7 +48,6 @@ fun PinDotsIndicator(
     filledCount: Int,
     error: Boolean,
     modifier: Modifier = Modifier,
-    length: Int = VAULT_PIN_LENGTH,
 ) {
     val offsetX = remember { Animatable(0f) }
 
@@ -64,7 +63,7 @@ fun PinDotsIndicator(
         modifier = modifier.offset(x = offsetX.value.dp),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        repeat(length) { index ->
+        repeat(VAULT_PIN_LENGTH) { index ->
             val filled = index < filledCount
             Spacer(
                 modifier = Modifier

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/vault/VaultBiometricButton.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/vault/VaultBiometricButton.kt
@@ -1,0 +1,93 @@
+package dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault
+
+import android.widget.Toast
+import androidx.activity.compose.LocalActivity
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
+import androidx.biometric.BiometricPrompt
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
+import dev.anilbeesetti.nextplayer.core.ui.R
+import dev.anilbeesetti.nextplayer.core.ui.designsystem.NextIcons
+
+@Composable
+internal fun VaultBiometricButton(
+    onAuthenticated: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val activity = LocalActivity.current as? FragmentActivity ?: return
+    val available = remember(activity) {
+        BiometricManager.from(activity).canAuthenticate(BIOMETRIC_STRONG) == BiometricManager.BIOMETRIC_SUCCESS
+    }
+    if (!available) return
+
+    val currentOnAuthenticated by rememberUpdatedState(onAuthenticated)
+    var active by remember(activity) { mutableStateOf(false) }
+    val prompt = remember(activity) {
+        BiometricPrompt(
+            activity,
+            object : BiometricPrompt.AuthenticationCallback() {
+                override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                    if (active) currentOnAuthenticated()
+                }
+
+                override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                    if (active && errorCode != BiometricPrompt.ERROR_NEGATIVE_BUTTON &&
+                        errorCode != BiometricPrompt.ERROR_USER_CANCELED && errorCode != BiometricPrompt.ERROR_CANCELED
+                    ) {
+                        Toast.makeText(activity, errString, Toast.LENGTH_SHORT).show()
+                    }
+                }
+            },
+        )
+    }
+    val promptInfo = remember(activity) {
+        BiometricPrompt.PromptInfo.Builder()
+            .setTitle(activity.getString(R.string.open_vault))
+            .setAllowedAuthenticators(BIOMETRIC_STRONG)
+            .setNegativeButtonText(activity.getString(R.string.use_vault_pin))
+            .build()
+    }
+
+    DisposableEffect(prompt) {
+        active = true
+        onDispose {
+            active = false
+            // AndroidX retains the prompt and reattaches its callback after rotation.
+            if (!activity.isChangingConfigurations) prompt.cancelAuthentication()
+        }
+    }
+
+    var prompted by rememberSaveable { mutableStateOf(false) }
+    LaunchedEffect(prompt) {
+        if (!prompted) {
+            prompted = true
+            prompt.authenticate(promptInfo)
+        }
+    }
+
+    TextButton(
+        modifier = modifier,
+        onClick = { prompt.authenticate(promptInfo) },
+    ) {
+        Icon(imageVector = NextIcons.Fingerprint, contentDescription = null)
+        Spacer(Modifier.size(8.dp))
+        Text(text = stringResource(R.string.unlock_with_biometrics))
+    }
+}

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/vault/VaultBiometricButton.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/vault/VaultBiometricButton.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import dev.anilbeesetti.nextplayer.core.ui.R
 import dev.anilbeesetti.nextplayer.core.ui.designsystem.NextIcons
 
@@ -31,37 +32,82 @@ internal fun VaultBiometricButton(
     onAuthenticated: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val activity = LocalActivity.current as? FragmentActivity ?: return
-    val available = remember(activity) {
-        BiometricManager.from(activity).canAuthenticate(BIOMETRIC_STRONG) == BiometricManager.BIOMETRIC_SUCCESS
-    }
-    if (!available) return
+    if (!rememberVaultBiometricAvailable()) return
 
-    val currentOnAuthenticated by rememberUpdatedState(onAuthenticated)
+    var showPrompt by rememberSaveable { mutableStateOf(true) }
+    if (showPrompt) {
+        VaultBiometricPrompt(
+            title = stringResource(R.string.open_vault),
+            negativeButtonText = stringResource(R.string.use_vault_pin),
+            onResult = { authenticated ->
+                showPrompt = false
+                if (authenticated) onAuthenticated()
+            },
+        )
+    }
+
+    TextButton(
+        modifier = modifier,
+        onClick = { showPrompt = true },
+    ) {
+        Icon(imageVector = NextIcons.Fingerprint, contentDescription = null)
+        Spacer(Modifier.size(8.dp))
+        Text(text = stringResource(R.string.unlock_with_biometrics))
+    }
+}
+
+@Composable
+internal fun rememberVaultBiometricAvailable(): Boolean {
+    val activity = LocalActivity.current as? FragmentActivity ?: return false
+    val manager = remember(activity) { BiometricManager.from(activity) }
+    var available by remember(manager) {
+        mutableStateOf(manager.canAuthenticate(BIOMETRIC_STRONG) == BiometricManager.BIOMETRIC_SUCCESS)
+    }
+    LifecycleResumeEffect(manager) {
+        available = manager.canAuthenticate(BIOMETRIC_STRONG) == BiometricManager.BIOMETRIC_SUCCESS
+        onPauseOrDispose { }
+    }
+    return available
+}
+
+@Composable
+internal fun VaultBiometricPrompt(
+    title: String,
+    negativeButtonText: String,
+    onResult: (Boolean) -> Unit,
+) {
+    val activity = LocalActivity.current as? FragmentActivity ?: return
+
+    val currentOnResult by rememberUpdatedState(onResult)
     var active by remember(activity) { mutableStateOf(false) }
     val prompt = remember(activity) {
         BiometricPrompt(
             activity,
             object : BiometricPrompt.AuthenticationCallback() {
                 override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
-                    if (active) currentOnAuthenticated()
+                    if (!active) return
+                    active = false
+                    currentOnResult(true)
                 }
 
                 override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
-                    if (active && errorCode != BiometricPrompt.ERROR_NEGATIVE_BUTTON &&
+                    if (!active) return
+                    active = false
+                    if (errorCode != BiometricPrompt.ERROR_NEGATIVE_BUTTON &&
                         errorCode != BiometricPrompt.ERROR_USER_CANCELED && errorCode != BiometricPrompt.ERROR_CANCELED
                     ) {
                         Toast.makeText(activity, errString, Toast.LENGTH_SHORT).show()
                     }
+                    currentOnResult(false)
                 }
             },
         )
     }
-    val promptInfo = remember(activity) {
+    val promptInfo = remember(title, negativeButtonText) {
         BiometricPrompt.PromptInfo.Builder()
-            .setTitle(activity.getString(R.string.open_vault))
+            .setTitle(title)
             .setAllowedAuthenticators(BIOMETRIC_STRONG)
-            .setNegativeButtonText(activity.getString(R.string.use_vault_pin))
+            .setNegativeButtonText(negativeButtonText)
             .build()
     }
 
@@ -80,14 +126,5 @@ internal fun VaultBiometricButton(
             prompted = true
             prompt.authenticate(promptInfo)
         }
-    }
-
-    TextButton(
-        modifier = modifier,
-        onClick = { prompt.authenticate(promptInfo) },
-    ) {
-        Icon(imageVector = NextIcons.Fingerprint, contentDescription = null)
-        Spacer(Modifier.size(8.dp))
-        Text(text = stringResource(R.string.unlock_with_biometrics))
     }
 }

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/vault/VaultBiometricSetupDialog.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/vault/VaultBiometricSetupDialog.kt
@@ -1,0 +1,49 @@
+package dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault
+
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import dev.anilbeesetti.nextplayer.core.ui.R
+import dev.anilbeesetti.nextplayer.core.ui.components.NextDialog
+
+@Composable
+internal fun VaultBiometricSetupDialog(onComplete: (Boolean) -> Unit) {
+    if (!rememberVaultBiometricAvailable()) {
+        LaunchedEffect(Unit) { onComplete(false) }
+        return
+    }
+
+    var authenticating by rememberSaveable { mutableStateOf(false) }
+    NextDialog(
+        onDismissRequest = { onComplete(false) },
+        title = { Text(stringResource(R.string.vault_biometric_setup_title)) },
+        content = { Text(stringResource(R.string.vault_biometric_setup_description)) },
+        confirmButton = {
+            TextButton(onClick = { authenticating = true }, enabled = !authenticating) {
+                Text(stringResource(R.string.enable_biometric_unlock))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { onComplete(false) }) {
+                Text(stringResource(R.string.not_now))
+            }
+        },
+    )
+
+    if (authenticating) {
+        VaultBiometricPrompt(
+            title = stringResource(R.string.enable_biometric_unlock),
+            negativeButtonText = stringResource(R.string.cancel),
+            onResult = { authenticated ->
+                authenticating = false
+                if (authenticated) onComplete(true)
+            },
+        )
+    }
+}

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/vault/VaultSettingsDialog.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/vault/VaultSettingsDialog.kt
@@ -1,0 +1,59 @@
+package dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault
+
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import dev.anilbeesetti.nextplayer.core.ui.R
+import dev.anilbeesetti.nextplayer.core.ui.components.NextDialog
+import dev.anilbeesetti.nextplayer.core.ui.components.PreferenceSwitch
+
+@Composable
+internal fun VaultSettingsDialog(
+    biometricEnabled: Boolean,
+    onBiometricEnabledChange: (Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val available = rememberVaultBiometricAvailable()
+    var authenticating by rememberSaveable { mutableStateOf(false) }
+
+    NextDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.vault_settings)) },
+        content = {
+            PreferenceSwitch(
+                title = stringResource(R.string.unlock_with_biometrics),
+                description = stringResource(
+                    if (available || biometricEnabled) R.string.vault_biometric_description else R.string.vault_biometric_unavailable,
+                ),
+                isChecked = biometricEnabled,
+                enabled = !authenticating && (biometricEnabled || available),
+                isFirstItem = true,
+                isLastItem = true,
+                onClick = {
+                    if (biometricEnabled) onBiometricEnabledChange(false) else authenticating = true
+                },
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.done))
+            }
+        },
+    )
+
+    if (authenticating) {
+        VaultBiometricPrompt(
+            title = stringResource(R.string.enable_biometric_unlock),
+            negativeButtonText = stringResource(R.string.cancel),
+            onResult = { authenticated ->
+                authenticating = false
+                if (authenticated) onBiometricEnabledChange(true)
+            },
+        )
+    }
+}

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/navigation/MediaPickerNavigation.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/navigation/MediaPickerNavigation.kt
@@ -1,6 +1,7 @@
 package dev.anilbeesetti.nextplayer.feature.videopicker.navigation
 
 import android.net.Uri
+import androidx.compose.runtime.SideEffect
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavBackStack
@@ -28,25 +29,25 @@ fun EntryProviderScope<NavKey>.mediaPickerEntry(
     onVaultClick: () -> Unit,
 ) {
     entry<MediaPickerRoute> { key ->
-        MediaPickerRoute(
-            viewModel = hiltViewModel<MediaPickerViewModel, MediaPickerViewModel.Factory>(
-                creationCallback = { factory ->
-                    factory.create(
-                        input = MediaPickerViewModel.Input(
-                            folderId = key.folderId,
-                        ),
-                        output = MediaPickerViewModel.Output(
-                            navigateUp = onNavigateUp,
-                            playVideo = onPlayVideo,
-                            playVideos = onPlayVideos,
-                            openFolder = onFolderClick,
-                            openSettings = onSettingsClick,
-                            openSearch = onSearchClick,
-                            openVault = onVaultClick,
-                        ),
-                    )
-                },
-            ),
+        val output = MediaPickerViewModel.Output(
+            navigateUp = onNavigateUp,
+            playVideo = onPlayVideo,
+            playVideos = onPlayVideos,
+            openFolder = onFolderClick,
+            openSettings = onSettingsClick,
+            openSearch = onSearchClick,
+            openVault = onVaultClick,
         )
+        val viewModel = hiltViewModel<MediaPickerViewModel, MediaPickerViewModel.Factory>(
+            creationCallback = { factory ->
+                factory.create(
+                    input = MediaPickerViewModel.Input(folderId = key.folderId),
+                    output = output,
+                )
+            },
+        )
+        // The ViewModel survives recreation; the activity's navigation stack does not.
+        SideEffect { viewModel.output = output }
+        MediaPickerRoute(viewModel = viewModel)
     }
 }

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerScreen.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerScreen.kt
@@ -126,6 +126,7 @@ import dev.anilbeesetti.nextplayer.feature.videopicker.composables.SelectionActi
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.TextIconToggleButton
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.PinDotsIndicator
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.PinKeypad
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.VaultBiometricSetupDialog
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.VaultProgressDialog
 import dev.anilbeesetti.nextplayer.feature.videopicker.screens.vault.VAULT_PIN_LENGTH
 import dev.anilbeesetti.nextplayer.feature.videopicker.state.SelectionItem
@@ -615,6 +616,7 @@ internal fun MediaPickerScreen(
         hideFlow = uiState.hideFlow,
         onConfirmHide = { onAction(MediaPickerAction.ConfirmHidePendingItems) },
         onSetPinAndHide = { onAction(MediaPickerAction.SetVaultPinAndHide(it)) },
+        onBiometricSetupComplete = { onAction(MediaPickerAction.CompleteBiometricSetup(it)) },
         onDismiss = { onAction(MediaPickerAction.DismissHideFlow) },
     )
 
@@ -801,6 +803,7 @@ private fun HideFlowDialogs(
     hideFlow: HideFlowState,
     onConfirmHide: () -> Unit,
     onSetPinAndHide: (String) -> Unit,
+    onBiometricSetupComplete: (Boolean) -> Unit,
     onDismiss: () -> Unit,
 ) {
     when (hideFlow) {
@@ -839,6 +842,8 @@ private fun HideFlowDialogs(
                 onPinConfirmed = onSetPinAndHide,
             )
         }
+
+        HideFlowState.BiometricSetup -> VaultBiometricSetupDialog(onComplete = onBiometricSetupComplete)
 
         HideFlowState.HowToFindInfo -> {
             NextDialog(

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerScreen.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateStartPadding
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -69,7 +68,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.pluralStringResource
@@ -124,6 +122,7 @@ import dev.anilbeesetti.nextplayer.feature.videopicker.composables.MediaView
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.NoVideosFound
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.QuickSettingsDialog
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.RenameDialog
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.SelectionAction
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.TextIconToggleButton
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.PinDotsIndicator
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.PinKeypad
@@ -480,65 +479,67 @@ internal fun MediaPickerScreen(
                     launchPermissionRequest = { permissionState.launchPermissionRequest() },
                 ) {}
             }
-        } else when (uiState.mediaDataState) {
-            is DataState.Error -> {
-            }
-
-            is DataState.Loading -> {
-                CenterCircularProgressBar(modifier = Modifier.padding(scaffoldPadding))
-            }
-
-            is DataState.Success -> {
-                val containerModifier = Modifier
-                    .fillMaxSize()
-                    .padding(top = scaffoldPadding.calculateTopPadding())
-                    .padding(start = scaffoldPadding.calculateStartPadding(LocalLayoutDirection.current) + 2.dp)
-                    .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
-                    .background(MaterialTheme.colorScheme.background)
-
-                val successContent: @Composable () -> Unit = {
-                    val updatedScaffoldPadding = scaffoldPadding.copy(
-                        top = 0.dp,
-                        start = 0.dp,
-                        bottom = scaffoldPadding.calculateBottomPadding(),
-                    )
-                    val mediaHolder = uiState.mediaDataState.value
-                    if (mediaHolder == null || mediaHolder.folders.isEmpty() && mediaHolder.videos.isEmpty()) {
-                        NoVideosFound(contentPadding = updatedScaffoldPadding)
-                    } else {
-                        MediaView(
-                            recentlyPlayedVideo = uiState.recentlyPlayedVideo,
-                            recentlyPlayedFolder = uiState.recentlyPlayedFolder,
-                            mediaHolder = mediaHolder,
-                            preferences = uiState.preferences,
-                            onFolderClick = { onAction(MediaPickerAction.OnFolderClick(it)) },
-                            onVideoClick = { onAction(MediaPickerAction.OnPlayVideo(it)) },
-                            selectionManager = selectionManager,
-                            lazyGridState = lazyGridState,
-                            firstItemFocusRequester = if (isTv) firstItemFocusRequester else null,
-                            lastItemFocusRequester = if (isTv) lastItemFocusRequester else null,
-                            restoredFocusKey = restoredFocusKey,
-                            onItemFocused = { restoredFocusKey = it },
-                            // Down from the last item goes to the FAB normally, or to the selection
-                            // action bar while selecting (the FAB is hidden then).
-                            lastItemDownFocusRequester = when {
-                                !isTv -> null
-                                selectionManager.isInSelectionMode -> firstActionFocusRequester
-                                else -> fabFocusRequester
-                            },
-                            contentPadding = updatedScaffoldPadding,
-                        )
-                    }
+        } else {
+            when (uiState.mediaDataState) {
+                is DataState.Error -> {
                 }
 
-                if (isTv) {
-                    Box(modifier = containerModifier) { successContent() }
-                } else {
-                    PullToRefreshBox(
-                        modifier = containerModifier,
-                        isRefreshing = uiState.refreshing,
-                        onRefresh = { onAction(MediaPickerAction.Refresh) },
-                    ) { successContent() }
+                is DataState.Loading -> {
+                    CenterCircularProgressBar(modifier = Modifier.padding(scaffoldPadding))
+                }
+
+                is DataState.Success -> {
+                    val containerModifier = Modifier
+                        .fillMaxSize()
+                        .padding(top = scaffoldPadding.calculateTopPadding())
+                        .padding(start = scaffoldPadding.calculateStartPadding(LocalLayoutDirection.current) + 2.dp)
+                        .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+                        .background(MaterialTheme.colorScheme.background)
+
+                    val successContent: @Composable () -> Unit = {
+                        val updatedScaffoldPadding = scaffoldPadding.copy(
+                            top = 0.dp,
+                            start = 0.dp,
+                            bottom = scaffoldPadding.calculateBottomPadding(),
+                        )
+                        val mediaHolder = uiState.mediaDataState.value
+                        if (mediaHolder == null || mediaHolder.folders.isEmpty() && mediaHolder.videos.isEmpty()) {
+                            NoVideosFound(contentPadding = updatedScaffoldPadding)
+                        } else {
+                            MediaView(
+                                recentlyPlayedVideo = uiState.recentlyPlayedVideo,
+                                recentlyPlayedFolder = uiState.recentlyPlayedFolder,
+                                mediaHolder = mediaHolder,
+                                preferences = uiState.preferences,
+                                onFolderClick = { onAction(MediaPickerAction.OnFolderClick(it)) },
+                                onVideoClick = { onAction(MediaPickerAction.OnPlayVideo(it)) },
+                                selectionManager = selectionManager,
+                                lazyGridState = lazyGridState,
+                                firstItemFocusRequester = if (isTv) firstItemFocusRequester else null,
+                                lastItemFocusRequester = if (isTv) lastItemFocusRequester else null,
+                                restoredFocusKey = restoredFocusKey,
+                                onItemFocused = { restoredFocusKey = it },
+                                // Down from the last item goes to the FAB normally, or to the selection
+                                // action bar while selecting (the FAB is hidden then).
+                                lastItemDownFocusRequester = when {
+                                    !isTv -> null
+                                    selectionManager.isInSelectionMode -> firstActionFocusRequester
+                                    else -> fabFocusRequester
+                                },
+                                contentPadding = updatedScaffoldPadding,
+                            )
+                        }
+                    }
+
+                    if (isTv) {
+                        Box(modifier = containerModifier) { successContent() }
+                    } else {
+                        PullToRefreshBox(
+                            modifier = containerModifier,
+                            isRefreshing = uiState.refreshing,
+                            onRefresh = { onAction(MediaPickerAction.Refresh) },
+                        ) { successContent() }
+                    }
                 }
             }
         }
@@ -1337,47 +1338,6 @@ private fun SelectionActionsSheet(
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun SelectionAction(
-    imageVector: ImageVector,
-    title: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    isTv: Boolean = false,
-) {
-    Column(
-        modifier = modifier
-            .defaultMinSize(
-                minWidth = 75.dp,
-                minHeight = 64.dp,
-            )
-            .tvFocusRing(isTv, shape = RoundedCornerShape(12.dp))
-            .clip(RoundedCornerShape(12.dp))
-            .clickable(onClick = onClick)
-            .padding(
-                horizontal = 16.dp,
-                vertical = 8.dp,
-            ),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Icon(
-            imageVector = imageVector,
-            contentDescription = title,
-            modifier = Modifier.size(24.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(modifier = Modifier.size(4.dp))
-        Text(
-            text = title,
-            modifier = Modifier,
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-        )
     }
 }
 

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerViewModel.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerViewModel.kt
@@ -134,6 +134,7 @@ class MediaPickerViewModel @AssistedInject constructor(
             MediaPickerAction.CancelTransfer -> cancelTransfer()
             is MediaPickerAction.RequestHideSelectedItems -> requestHideSelectedItems(action.selectionItems)
             is MediaPickerAction.SetVaultPinAndHide -> setVaultPinAndHide(action.pin)
+            is MediaPickerAction.CompleteBiometricSetup -> completeBiometricSetup(action.enabled)
             MediaPickerAction.ConfirmHidePendingItems -> confirmHidePendingItems()
             MediaPickerAction.DismissHideFlow -> uiStateInternal.update { it.copy(hideFlow = HideFlowState.Idle) }
             is MediaPickerAction.ShowAddToPlaylist -> showAddToPlaylist(action.selectionItems)
@@ -458,6 +459,14 @@ class MediaPickerViewModel @AssistedInject constructor(
             vaultPinRepository.setPin(pin)
             hideVideoItems(pending)
             vaultPinRepository.setHideConfirmationShown()
+            uiStateInternal.update { it.copy(hideFlow = HideFlowState.BiometricSetup) }
+        }
+    }
+
+    private fun completeBiometricSetup(enabled: Boolean) {
+        if (uiStateInternal.value.hideFlow != HideFlowState.BiometricSetup) return
+        viewModelScope.launch {
+            vaultPinRepository.setBiometricEnabled(enabled)
             uiStateInternal.update { it.copy(hideFlow = HideFlowState.HowToFindInfo) }
         }
     }
@@ -532,6 +541,7 @@ sealed interface HideFlowState {
     data object Idle : HideFlowState
     data class ConfirmHide(val items: List<Video>) : HideFlowState
     data class SetupPin(val items: List<Video>) : HideFlowState
+    data object BiometricSetup : HideFlowState
     data object HowToFindInfo : HideFlowState
 
     data object Processing : HideFlowState
@@ -558,6 +568,7 @@ sealed interface MediaPickerAction {
     data object DismissMediaInfo : MediaPickerAction
     data class RequestHideSelectedItems(val selectionItems: Set<SelectionItem>) : MediaPickerAction
     data class SetVaultPinAndHide(val pin: String) : MediaPickerAction
+    data class CompleteBiometricSetup(val enabled: Boolean) : MediaPickerAction
     data object ConfirmHidePendingItems : MediaPickerAction
     data object DismissHideFlow : MediaPickerAction
     data class ShowAddToPlaylist(val selectionItems: Set<SelectionItem>) : MediaPickerAction

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerViewModel.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerViewModel.kt
@@ -39,9 +39,10 @@ import dev.anilbeesetti.nextplayer.core.model.PlaylistSummary
 import dev.anilbeesetti.nextplayer.core.model.PlaylistType
 import dev.anilbeesetti.nextplayer.core.model.Video
 import dev.anilbeesetti.nextplayer.core.model.findClosestFolder
-import dev.anilbeesetti.nextplayer.core.ui.base.DataState
 import dev.anilbeesetti.nextplayer.core.ui.R
+import dev.anilbeesetti.nextplayer.core.ui.base.DataState
 import dev.anilbeesetti.nextplayer.feature.videopicker.state.SelectionItem
+import java.io.File
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -49,7 +50,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.io.File
 
 @HiltViewModel(assistedFactory = MediaPickerViewModel.Factory::class)
 class MediaPickerViewModel @AssistedInject constructor(
@@ -66,7 +66,7 @@ class MediaPickerViewModel @AssistedInject constructor(
     private val systemService: SystemService,
     @ApplicationContext private val context: Context,
     @Assisted private val input: Input,
-    @Assisted private val output: Output,
+    @Assisted internal var output: Output,
 ) : ViewModel() {
 
     data class Input(
@@ -164,7 +164,7 @@ class MediaPickerViewModel @AssistedInject constructor(
                     currentState.copy(
                         mediaDataState = DataState.Success(media),
                         recentlyPlayedVideo = recentlyPlayed,
-                        recentlyPlayedFolder = recentlyPlayed?.let { media?.folders?.findClosestFolder(it.path) }
+                        recentlyPlayedFolder = recentlyPlayed?.let { media?.folders?.findClosestFolder(it.path) },
                     )
                 }
             }
@@ -185,9 +185,11 @@ class MediaPickerViewModel @AssistedInject constructor(
         viewModelScope.launch {
             playlistRepository.observePlaylists().collect { playlists ->
                 uiStateInternal.update {
-                    it.copy(playlists = playlists.filter { playlist ->
-                        playlist.type == PlaylistType.LOCAL
-                    })
+                    it.copy(
+                        playlists = playlists.filter { playlist ->
+                            playlist.type == PlaylistType.LOCAL
+                        },
+                    )
                 }
             }
         }

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt
@@ -92,7 +92,9 @@ import dev.anilbeesetti.nextplayer.feature.videopicker.composables.VideoItem
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.PinDotsIndicator
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.PinKeypad
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.VaultBiometricButton
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.VaultBiometricSetupDialog
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.VaultProgressDialog
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.VaultSettingsDialog
 import dev.anilbeesetti.nextplayer.feature.videopicker.state.SelectionItem
 import dev.anilbeesetti.nextplayer.feature.videopicker.state.rememberSelectionManager
 
@@ -149,7 +151,11 @@ internal fun VaultScreen(
             pinErrorCount = uiState.pinErrorCount,
             errorMessage = stringResource(R.string.incorrect_pin),
             onSubmit = { onAction(VaultAction.SubmitUnlockPin(it)) },
-            onBiometricAuthenticated = { onAction(VaultAction.BiometricAuthenticated) },
+            onBiometricAuthenticated = if (uiState.biometricEnabled) {
+                { onAction(VaultAction.BiometricAuthenticated) }
+            } else {
+                null
+            },
             onNavigateUp = onNavigateUp,
         )
 
@@ -168,6 +174,10 @@ internal fun VaultScreen(
             errorMessage = stringResource(R.string.pins_do_not_match),
             onSubmit = { onAction(VaultAction.SubmitPinConfirmation(it)) },
             onNavigateUp = onNavigateUp,
+        )
+
+        VaultStage.BIOMETRIC_SETUP -> VaultBiometricSetupDialog(
+            onComplete = { onAction(VaultAction.CompleteBiometricSetup(it)) },
         )
 
         VaultStage.HOW_TO_FIND_INFO -> {
@@ -407,6 +417,7 @@ private fun VaultGalleryScreen(
     var restoredFocusKey by rememberSaveable { mutableStateOf<String?>(null) }
     val selectionManager = rememberSelectionManager()
     var showSortMenu by rememberSaveable { mutableStateOf(false) }
+    var showSettings by rememberSaveable { mutableStateOf(false) }
     var showDeleteConfirmation by rememberSaveable { mutableStateOf(false) }
     var showUnhideConfirmation by rememberSaveable { mutableStateOf(false) }
 
@@ -502,6 +513,15 @@ private fun VaultGalleryScreen(
                             Icon(
                                 imageVector = NextIcons.Sensitivity,
                                 contentDescription = stringResource(R.string.sort_by),
+                            )
+                        }
+                        IconButton(
+                            onClick = { showSettings = true },
+                            modifier = Modifier.tvFocusRing(),
+                        ) {
+                            Icon(
+                                imageVector = NextIcons.Settings,
+                                contentDescription = stringResource(R.string.vault_settings),
                             )
                         }
                     }
@@ -610,6 +630,14 @@ private fun VaultGalleryScreen(
                 }
             }
         }
+    }
+
+    if (showSettings) {
+        VaultSettingsDialog(
+            biometricEnabled = uiState.biometricEnabled,
+            onBiometricEnabledChange = { onAction(VaultAction.SetBiometricEnabled(it)) },
+            onDismiss = { showSettings = false },
+        )
     }
 
     if (showSortMenu) {

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt
@@ -85,11 +85,13 @@ import dev.anilbeesetti.nextplayer.core.ui.components.tvFocusRing
 import dev.anilbeesetti.nextplayer.core.ui.designsystem.NextIcons
 import dev.anilbeesetti.nextplayer.core.ui.extensions.copy
 import dev.anilbeesetti.nextplayer.core.ui.theme.NextPlayerTheme
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.CenterCircularProgressBar
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.MediaInfoDialog
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.SelectionAction
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.VideoItem
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.PinDotsIndicator
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.PinKeypad
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.VaultBiometricButton
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.VaultProgressDialog
 import dev.anilbeesetti.nextplayer.feature.videopicker.state.SelectionItem
 import dev.anilbeesetti.nextplayer.feature.videopicker.state.rememberSelectionManager
@@ -139,12 +141,15 @@ internal fun VaultScreen(
     onNavigateUp: () -> Unit,
 ) {
     when (uiState.stage) {
+        VaultStage.LOADING -> CenterCircularProgressBar()
+
         VaultStage.LOCKED -> VaultPinScreen(
             title = stringResource(R.string.enter_vault_pin),
             description = stringResource(R.string.enter_vault_pin_description),
             pinErrorCount = uiState.pinErrorCount,
             errorMessage = stringResource(R.string.incorrect_pin),
             onSubmit = { onAction(VaultAction.SubmitUnlockPin(it)) },
+            onBiometricAuthenticated = { onAction(VaultAction.BiometricAuthenticated) },
             onNavigateUp = onNavigateUp,
         )
 
@@ -192,6 +197,7 @@ private fun VaultPinScreen(
     onSubmit: (String) -> Unit,
     onNavigateUp: () -> Unit,
     errorMessage: String = "",
+    onBiometricAuthenticated: (() -> Unit)? = null,
 ) {
     Scaffold(
         topBar = {
@@ -209,6 +215,17 @@ private fun VaultPinScreen(
                     }
                 },
             )
+        },
+        bottomBar = {
+            onBiometricAuthenticated?.let { onAuthenticated ->
+                VaultBiometricButton(
+                    onAuthenticated = onAuthenticated,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .navigationBarsPadding()
+                        .padding(horizontal = 24.dp, vertical = 8.dp),
+                )
+            }
         },
         containerColor = MaterialTheme.colorScheme.surfaceContainer,
     ) { padding ->

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.calculateStartPadding
-import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -28,7 +27,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
@@ -59,7 +57,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
@@ -89,10 +86,11 @@ import dev.anilbeesetti.nextplayer.core.ui.designsystem.NextIcons
 import dev.anilbeesetti.nextplayer.core.ui.extensions.copy
 import dev.anilbeesetti.nextplayer.core.ui.theme.NextPlayerTheme
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.MediaInfoDialog
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.SelectionAction
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.VideoItem
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.PinDotsIndicator
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.PinKeypad
 import dev.anilbeesetti.nextplayer.feature.videopicker.composables.vault.VaultProgressDialog
-import dev.anilbeesetti.nextplayer.feature.videopicker.composables.VideoItem
 import dev.anilbeesetti.nextplayer.feature.videopicker.state.SelectionItem
 import dev.anilbeesetti.nextplayer.feature.videopicker.state.rememberSelectionManager
 
@@ -216,7 +214,6 @@ private fun VaultPinScreen(
     ) { padding ->
         PinEntryContent(
             modifier = Modifier.padding(padding),
-            icon = NextIcons.Lock,
             title = title,
             description = description,
             pinErrorCount = pinErrorCount,
@@ -229,7 +226,6 @@ private fun VaultPinScreen(
 @Composable
 private fun PinEntryContent(
     modifier: Modifier = Modifier,
-    icon: ImageVector,
     title: String,
     description: String,
     pinErrorCount: Int,
@@ -268,7 +264,6 @@ private fun PinEntryContent(
         ) {
             PinEntryHeader(
                 modifier = Modifier.weight(1f),
-                icon = icon,
                 title = title,
                 description = description,
                 filledCount = pin.length,
@@ -292,7 +287,6 @@ private fun PinEntryContent(
         ) {
             Spacer(modifier = Modifier.size(16.dp))
             PinEntryHeader(
-                icon = icon,
                 title = title,
                 description = description,
                 filledCount = pin.length,
@@ -312,7 +306,6 @@ private fun PinEntryContent(
 
 @Composable
 private fun PinEntryHeader(
-    icon: ImageVector,
     title: String,
     description: String,
     filledCount: Int,
@@ -332,7 +325,7 @@ private fun PinEntryHeader(
             contentAlignment = Alignment.Center,
         ) {
             Icon(
-                imageVector = icon,
+                imageVector = NextIcons.Lock,
                 contentDescription = null,
                 tint = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.size(32.dp),
@@ -532,7 +525,7 @@ private fun VaultGalleryScreen(
                 uiState.isLoading -> {
                     Box(
                         modifier = Modifier.fillMaxSize().padding(updatedPadding),
-                        contentAlignment = Alignment.Center
+                        contentAlignment = Alignment.Center,
                     ) {
                         CircularProgressIndicator()
                     }
@@ -827,7 +820,7 @@ private fun VaultSelectionActionsSheet(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceEvenly,
             ) {
-                VaultSelectionAction(
+                SelectionAction(
                     modifier = Modifier.focusRequester(firstActionFocusRequester),
                     isTv = isTv,
                     imageVector = NextIcons.Play,
@@ -835,20 +828,20 @@ private fun VaultSelectionActionsSheet(
                     onClick = onPlayAction,
                 )
                 if (showInfoAction) {
-                    VaultSelectionAction(
+                    SelectionAction(
                         isTv = isTv,
                         imageVector = NextIcons.Info,
                         title = stringResource(R.string.info),
                         onClick = onInfoAction,
                     )
                 }
-                VaultSelectionAction(
+                SelectionAction(
                     isTv = isTv,
                     imageVector = NextIcons.Lock,
                     title = stringResource(R.string.unhide),
                     onClick = onUnhideAction,
                 )
-                VaultSelectionAction(
+                SelectionAction(
                     isTv = isTv,
                     imageVector = NextIcons.Delete,
                     title = stringResource(R.string.delete),
@@ -856,47 +849,6 @@ private fun VaultSelectionActionsSheet(
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun VaultSelectionAction(
-    imageVector: ImageVector,
-    title: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    isTv: Boolean = false,
-) {
-    Column(
-        modifier = modifier
-            .defaultMinSize(
-                minWidth = 75.dp,
-                minHeight = 64.dp,
-            )
-            .tvFocusRing(isTv, shape = RoundedCornerShape(12.dp))
-            .clip(RoundedCornerShape(12.dp))
-            .clickable(onClick = onClick)
-            .padding(
-                horizontal = 16.dp,
-                vertical = 8.dp,
-            ),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Icon(
-            imageVector = imageVector,
-            contentDescription = title,
-            modifier = Modifier.size(24.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(modifier = Modifier.size(4.dp))
-        Text(
-            text = title,
-            modifier = Modifier,
-            style = MaterialTheme.typography.labelLarge,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-        )
     }
 }
 

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt
@@ -72,6 +72,9 @@ class VaultViewModel @Inject constructor(
             is VaultAction.SubmitNewPin -> submitNewPin(action.pin)
             is VaultAction.SubmitPinConfirmation -> submitPinConfirmation(action.pin)
             is VaultAction.SubmitUnlockPin -> submitUnlockPin(action.pin)
+            VaultAction.BiometricAuthenticated -> {
+                if (uiStateInternal.value.stage == VaultStage.LOCKED) unlockVault()
+            }
             VaultAction.DismissHowToFindInfo -> dismissHowToFindInfo()
             is VaultAction.PlayVideo -> playVideo(action.video)
             is VaultAction.PlaySelected -> playSelected(action.selectionItems)
@@ -125,8 +128,7 @@ class VaultViewModel @Inject constructor(
         viewModelScope.launch {
             val isValid = vaultPinRepository.verifyPin(pin)
             if (isValid) {
-                uiStateInternal.update { it.copy(stage = VaultStage.UNLOCKED, pinErrorCount = 0) }
-                collectHiddenVideos()
+                unlockVault()
             } else {
                 uiStateInternal.update { it.copy(pinErrorCount = it.pinErrorCount + 1) }
             }
@@ -134,7 +136,11 @@ class VaultViewModel @Inject constructor(
     }
 
     private fun dismissHowToFindInfo() {
-        uiStateInternal.update { it.copy(stage = VaultStage.UNLOCKED) }
+        unlockVault()
+    }
+
+    private fun unlockVault() {
+        uiStateInternal.update { it.copy(stage = VaultStage.UNLOCKED, pinErrorCount = 0) }
         collectHiddenVideos()
     }
 
@@ -196,6 +202,7 @@ class VaultViewModel @Inject constructor(
 }
 
 enum class VaultStage {
+    LOADING,
     LOCKED,
     SET_PIN,
     CONFIRM_PIN,
@@ -205,7 +212,7 @@ enum class VaultStage {
 
 @Stable
 data class VaultUiState(
-    val stage: VaultStage = VaultStage.LOCKED,
+    val stage: VaultStage = VaultStage.LOADING,
     val pendingPin: String? = null,
     val pinErrorCount: Int = 0,
     val setPinGeneration: Int = 0,
@@ -221,6 +228,7 @@ sealed interface VaultAction {
     data class SubmitNewPin(val pin: String) : VaultAction
     data class SubmitPinConfirmation(val pin: String) : VaultAction
     data class SubmitUnlockPin(val pin: String) : VaultAction
+    data object BiometricAuthenticated : VaultAction
     data object DismissHowToFindInfo : VaultAction
     data class PlayVideo(val video: Video) : VaultAction
     data class PlaySelected(val selectionItems: Set<SelectionItem>) : VaultAction

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt
@@ -46,8 +46,12 @@ class VaultViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             val hasPin = vaultPinRepository.hasPinSet()
+            val biometricEnabled = hasPin && vaultPinRepository.isBiometricEnabled()
             uiStateInternal.update {
-                it.copy(stage = if (hasPin) VaultStage.LOCKED else VaultStage.SET_PIN)
+                it.copy(
+                    stage = if (hasPin) VaultStage.LOCKED else VaultStage.SET_PIN,
+                    biometricEnabled = biometricEnabled,
+                )
             }
         }
         viewModelScope.launch {
@@ -73,8 +77,10 @@ class VaultViewModel @Inject constructor(
             is VaultAction.SubmitPinConfirmation -> submitPinConfirmation(action.pin)
             is VaultAction.SubmitUnlockPin -> submitUnlockPin(action.pin)
             VaultAction.BiometricAuthenticated -> {
-                if (uiStateInternal.value.stage == VaultStage.LOCKED) unlockVault()
+                if (uiStateInternal.value.stage == VaultStage.LOCKED && uiStateInternal.value.biometricEnabled) unlockVault()
             }
+            is VaultAction.CompleteBiometricSetup -> completeBiometricSetup(action.enabled)
+            is VaultAction.SetBiometricEnabled -> setBiometricEnabled(action.enabled)
             VaultAction.DismissHowToFindInfo -> dismissHowToFindInfo()
             is VaultAction.PlayVideo -> playVideo(action.video)
             is VaultAction.PlaySelected -> playSelected(action.selectionItems)
@@ -116,7 +122,7 @@ class VaultViewModel @Inject constructor(
             vaultPinRepository.setPin(pin)
             uiStateInternal.update {
                 it.copy(
-                    stage = VaultStage.HOW_TO_FIND_INFO,
+                    stage = VaultStage.BIOMETRIC_SETUP,
                     pendingPin = null,
                     pinErrorCount = 0,
                 )
@@ -132,6 +138,22 @@ class VaultViewModel @Inject constructor(
             } else {
                 uiStateInternal.update { it.copy(pinErrorCount = it.pinErrorCount + 1) }
             }
+        }
+    }
+
+    private fun completeBiometricSetup(enabled: Boolean) {
+        if (uiStateInternal.value.stage != VaultStage.BIOMETRIC_SETUP) return
+        viewModelScope.launch {
+            vaultPinRepository.setBiometricEnabled(enabled)
+            uiStateInternal.update { it.copy(stage = VaultStage.HOW_TO_FIND_INFO, biometricEnabled = enabled) }
+        }
+    }
+
+    private fun setBiometricEnabled(enabled: Boolean) {
+        if (uiStateInternal.value.stage != VaultStage.UNLOCKED) return
+        viewModelScope.launch {
+            vaultPinRepository.setBiometricEnabled(enabled)
+            uiStateInternal.update { it.copy(biometricEnabled = enabled) }
         }
     }
 
@@ -206,6 +228,7 @@ enum class VaultStage {
     LOCKED,
     SET_PIN,
     CONFIRM_PIN,
+    BIOMETRIC_SETUP,
     HOW_TO_FIND_INFO,
     UNLOCKED,
 }
@@ -216,6 +239,7 @@ data class VaultUiState(
     val pendingPin: String? = null,
     val pinErrorCount: Int = 0,
     val setPinGeneration: Int = 0,
+    val biometricEnabled: Boolean = false,
     val hiddenVideos: List<Video> = emptyList(),
     val isLoading: Boolean = false,
     val isUnhiding: Boolean = false,
@@ -229,6 +253,8 @@ sealed interface VaultAction {
     data class SubmitPinConfirmation(val pin: String) : VaultAction
     data class SubmitUnlockPin(val pin: String) : VaultAction
     data object BiometricAuthenticated : VaultAction
+    data class CompleteBiometricSetup(val enabled: Boolean) : VaultAction
+    data class SetBiometricEnabled(val enabled: Boolean) : VaultAction
     data object DismissHowToFindInfo : VaultAction
     data class PlayVideo(val video: Video) : VaultAction
     data class PlaySelected(val selectionItems: Set<SelectionItem>) : VaultAction

--- a/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultAuthenticationTest.kt
+++ b/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultAuthenticationTest.kt
@@ -22,6 +22,8 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,6 +34,7 @@ import org.robolectric.RobolectricTestRunner
 class VaultAuthenticationTest {
     private val dispatcher = StandardTestDispatcher()
     private val vaultRepository = FakeVaultRepository()
+    private var biometricEnabled = false
 
     @Before
     fun setUp() {
@@ -73,6 +76,7 @@ class VaultAuthenticationTest {
 
     @Test
     fun `successful biometrics unlock once and clear earlier PIN errors`() = runTest(dispatcher.scheduler) {
+        biometricEnabled = true
         val viewModel = createViewModel()
         advanceUntilIdle()
         viewModel.onAction(VaultAction.SubmitUnlockPin("0000"))
@@ -93,6 +97,7 @@ class VaultAuthenticationTest {
 
     @Test
     fun `PIN fallback still unlocks the vault`() = runTest(dispatcher.scheduler) {
+        biometricEnabled = true
         val viewModel = createViewModel()
         advanceUntilIdle()
 
@@ -103,11 +108,107 @@ class VaultAuthenticationTest {
         assertEquals(listOf(Video.sample), viewModel.uiState.value.hiddenVideos)
     }
 
+    @Test
+    fun `biometrics cannot unlock without opting in`() = runTest(dispatcher.scheduler) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onAction(VaultAction.BiometricAuthenticated)
+        advanceUntilIdle()
+
+        assertEquals(VaultStage.LOCKED, viewModel.uiState.value.stage)
+        assertEquals(0, vaultRepository.observations)
+    }
+
+    @Test
+    fun `confirming a new PIN offers biometrics without enabling it`() = runTest(dispatcher.scheduler) {
+        val viewModel = createViewModel(CompletableDeferred(false))
+        advanceUntilIdle()
+        viewModel.onAction(VaultAction.SubmitNewPin("1234"))
+        viewModel.onAction(VaultAction.SubmitPinConfirmation("1234"))
+        advanceUntilIdle()
+
+        assertEquals(VaultStage.BIOMETRIC_SETUP, viewModel.uiState.value.stage)
+        assertFalse(biometricEnabled)
+        viewModel.onAction(VaultAction.BiometricAuthenticated)
+        assertEquals(VaultStage.BIOMETRIC_SETUP, viewModel.uiState.value.stage)
+        assertEquals(0, vaultRepository.observations)
+
+        viewModel.onAction(VaultAction.CompleteBiometricSetup(true))
+        advanceUntilIdle()
+
+        assertTrue(biometricEnabled)
+        assertTrue(viewModel.uiState.value.biometricEnabled)
+        assertEquals(VaultStage.HOW_TO_FIND_INFO, viewModel.uiState.value.stage)
+        val reopened = createViewModel()
+        advanceUntilIdle()
+        assertTrue(reopened.uiState.value.biometricEnabled)
+    }
+
+    @Test
+    fun `skipping biometric setup keeps the next unlock PIN only`() = runTest(dispatcher.scheduler) {
+        val viewModel = createViewModel(CompletableDeferred(false))
+        advanceUntilIdle()
+        viewModel.onAction(VaultAction.SubmitNewPin("1234"))
+        viewModel.onAction(VaultAction.SubmitPinConfirmation("1234"))
+        advanceUntilIdle()
+        viewModel.onAction(VaultAction.CompleteBiometricSetup(false))
+        advanceUntilIdle()
+
+        assertFalse(biometricEnabled)
+        assertEquals(VaultStage.HOW_TO_FIND_INFO, viewModel.uiState.value.stage)
+        val reopened = createViewModel()
+        advanceUntilIdle()
+        reopened.onAction(VaultAction.BiometricAuthenticated)
+        assertEquals(VaultStage.LOCKED, reopened.uiState.value.stage)
+    }
+
+    @Test
+    fun `biometric settings cannot be changed from the locked screen`() = runTest(dispatcher.scheduler) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onAction(VaultAction.SetBiometricEnabled(true))
+        viewModel.onAction(VaultAction.CompleteBiometricSetup(true))
+        advanceUntilIdle()
+
+        assertFalse(biometricEnabled)
+        assertEquals(VaultStage.LOCKED, viewModel.uiState.value.stage)
+    }
+
+    @Test
+    fun `biometrics can be enabled in the unlocked vault and disabled for later visits`() = runTest(dispatcher.scheduler) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onAction(VaultAction.SubmitUnlockPin("1234"))
+        advanceUntilIdle()
+        viewModel.onAction(VaultAction.SetBiometricEnabled(true))
+        advanceUntilIdle()
+        assertTrue(biometricEnabled)
+
+        viewModel.onAction(VaultAction.SetBiometricEnabled(false))
+        advanceUntilIdle()
+        assertFalse(viewModel.uiState.value.biometricEnabled)
+        assertFalse(biometricEnabled)
+
+        val reopened = createViewModel()
+        advanceUntilIdle()
+        reopened.onAction(VaultAction.BiometricAuthenticated)
+        assertEquals(VaultStage.LOCKED, reopened.uiState.value.stage)
+        reopened.onAction(VaultAction.SubmitUnlockPin("1234"))
+        advanceUntilIdle()
+        assertEquals(VaultStage.UNLOCKED, reopened.uiState.value.stage)
+    }
+
     private fun createViewModel(hasPin: CompletableDeferred<Boolean> = CompletableDeferred(true)) = VaultViewModel(
         vaultRepository = vaultRepository,
         vaultPinRepository = object : VaultPinRepository {
             override suspend fun hasPinSet(): Boolean = hasPin.await()
             override suspend fun setPin(pin: String) = Unit
+            override suspend fun isBiometricEnabled(): Boolean = biometricEnabled
+            override suspend fun setBiometricEnabled(enabled: Boolean) {
+                biometricEnabled = enabled
+            }
             override suspend fun verifyPin(pin: String): Boolean = pin == "1234"
             override suspend fun hasShownHideConfirmation(): Boolean = false
             override suspend fun setHideConfirmationShown() = Unit

--- a/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultAuthenticationTest.kt
+++ b/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultAuthenticationTest.kt
@@ -1,0 +1,138 @@
+package dev.anilbeesetti.nextplayer.feature.videopicker.screens.vault
+
+import dev.anilbeesetti.nextplayer.core.data.repository.PreferencesRepository
+import dev.anilbeesetti.nextplayer.core.data.repository.UnhideResult
+import dev.anilbeesetti.nextplayer.core.data.repository.VaultPinRepository
+import dev.anilbeesetti.nextplayer.core.data.repository.VaultRepository
+import dev.anilbeesetti.nextplayer.core.domain.GetHiddenVideosUseCase
+import dev.anilbeesetti.nextplayer.core.model.ApplicationPreferences
+import dev.anilbeesetti.nextplayer.core.model.MediaInfo
+import dev.anilbeesetti.nextplayer.core.model.PlayerPreferences
+import dev.anilbeesetti.nextplayer.core.model.Video
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class VaultAuthenticationTest {
+    private val dispatcher = StandardTestDispatcher()
+    private val vaultRepository = FakeVaultRepository()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `biometrics cannot unlock before PIN configuration is loaded`() = runTest(dispatcher.scheduler) {
+        val hasPin = CompletableDeferred<Boolean>()
+        val viewModel = createViewModel(hasPin)
+        advanceUntilIdle()
+
+        viewModel.onAction(VaultAction.BiometricAuthenticated)
+
+        assertEquals(VaultStage.LOADING, viewModel.uiState.value.stage)
+        assertEquals(0, vaultRepository.observations)
+        hasPin.complete(true)
+        advanceUntilIdle()
+        assertEquals(VaultStage.LOCKED, viewModel.uiState.value.stage)
+    }
+
+    @Test
+    fun `biometrics cannot bypass PIN setup or confirmation`() = runTest(dispatcher.scheduler) {
+        val viewModel = createViewModel(CompletableDeferred(false))
+        advanceUntilIdle()
+
+        viewModel.onAction(VaultAction.BiometricAuthenticated)
+        assertEquals(VaultStage.SET_PIN, viewModel.uiState.value.stage)
+        viewModel.onAction(VaultAction.SubmitNewPin("1234"))
+        viewModel.onAction(VaultAction.BiometricAuthenticated)
+        assertEquals(VaultStage.CONFIRM_PIN, viewModel.uiState.value.stage)
+        assertEquals(0, vaultRepository.observations)
+    }
+
+    @Test
+    fun `successful biometrics unlock once and clear earlier PIN errors`() = runTest(dispatcher.scheduler) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        viewModel.onAction(VaultAction.SubmitUnlockPin("0000"))
+        advanceUntilIdle()
+        assertEquals(VaultStage.LOCKED, viewModel.uiState.value.stage)
+        assertEquals(1, viewModel.uiState.value.pinErrorCount)
+
+        viewModel.onAction(VaultAction.BiometricAuthenticated)
+        advanceUntilIdle()
+        viewModel.onAction(VaultAction.BiometricAuthenticated)
+        advanceUntilIdle()
+
+        assertEquals(VaultStage.UNLOCKED, viewModel.uiState.value.stage)
+        assertEquals(0, viewModel.uiState.value.pinErrorCount)
+        assertEquals(listOf(Video.sample), viewModel.uiState.value.hiddenVideos)
+        assertEquals(1, vaultRepository.observations)
+    }
+
+    @Test
+    fun `PIN fallback still unlocks the vault`() = runTest(dispatcher.scheduler) {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onAction(VaultAction.SubmitUnlockPin("1234"))
+        advanceUntilIdle()
+
+        assertEquals(VaultStage.UNLOCKED, viewModel.uiState.value.stage)
+        assertEquals(listOf(Video.sample), viewModel.uiState.value.hiddenVideos)
+    }
+
+    private fun createViewModel(hasPin: CompletableDeferred<Boolean> = CompletableDeferred(true)) = VaultViewModel(
+        vaultRepository = vaultRepository,
+        vaultPinRepository = object : VaultPinRepository {
+            override suspend fun hasPinSet(): Boolean = hasPin.await()
+            override suspend fun setPin(pin: String) = Unit
+            override suspend fun verifyPin(pin: String): Boolean = pin == "1234"
+            override suspend fun hasShownHideConfirmation(): Boolean = false
+            override suspend fun setHideConfirmationShown() = Unit
+        },
+        getHiddenVideosUseCase = GetHiddenVideosUseCase(vaultRepository, dispatcher),
+        preferencesRepository = object : PreferencesRepository {
+            override val applicationPreferences = MutableStateFlow(ApplicationPreferences())
+            override val playerPreferences = MutableStateFlow(PlayerPreferences())
+            override suspend fun updateApplicationPreferences(transform: suspend (ApplicationPreferences) -> ApplicationPreferences) = Unit
+            override suspend fun updatePlayerPreferences(transform: suspend (PlayerPreferences) -> PlayerPreferences) = Unit
+            override suspend fun resetPreferences() = Unit
+        },
+    )
+
+    private class FakeVaultRepository : VaultRepository {
+        var observations = 0
+
+        override fun observeHiddenVideos(): Flow<List<Video>> {
+            observations++
+            return flowOf(listOf(Video.sample))
+        }
+
+        override suspend fun hideVideos(videos: List<Video>) = Unit
+        override suspend fun unhideVideos(videos: List<Video>) = UnhideResult()
+        override suspend fun deleteHiddenVideos(videos: List<Video>) = Unit
+        override suspend fun getHiddenVideoInfo(id: Long): MediaInfo? = null
+    }
+}

--- a/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultPlaybackEventTest.kt
+++ b/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultPlaybackEventTest.kt
@@ -75,6 +75,8 @@ class VaultPlaybackEventTest {
     private data object FakeVaultPinRepository : VaultPinRepository {
         override suspend fun hasPinSet(): Boolean = false
         override suspend fun setPin(pin: String) = Unit
+        override suspend fun isBiometricEnabled(): Boolean = false
+        override suspend fun setBiometricEnabled(enabled: Boolean) = Unit
         override suspend fun verifyPin(pin: String): Boolean = false
         override suspend fun hasShownHideConfirmation(): Boolean = false
         override suspend fun setHideConfirmationShown() = Unit

--- a/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultSortingTest.kt
+++ b/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultSortingTest.kt
@@ -224,6 +224,8 @@ class VaultSortingTest {
     private data object FakeVaultPinRepository : VaultPinRepository {
         override suspend fun hasPinSet(): Boolean = true
         override suspend fun setPin(pin: String) = Unit
+        override suspend fun isBiometricEnabled(): Boolean = false
+        override suspend fun setBiometricEnabled(enabled: Boolean) = Unit
         override suspend fun verifyPin(pin: String): Boolean = true
         override suspend fun hasShownHideConfirmation(): Boolean = false
         override suspend fun setHideConfirmationShown() = Unit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ androidGradlePlugin = "9.3.1"
 androidMaterial = "1.14.0"
 androidxActivity = "1.13.0"
 androidxAppCompat = "1.7.1"
+androidxBiometric = "1.1.0"
 androidxComposeBom = "2026.08.00"
 androidxMaterial3 = "1.5.0-alpha17"
 androidxMaterial3Adaptive = "1.3.0-rc01"
@@ -24,6 +25,7 @@ androidxMedia3 = "1.11.0"
 androidxNavigation3 = "1.1.6"
 androidxLifecycleViewmodelNav3 = "2.11.0"
 androidxTestExt = "1.3.0"
+androidxTestRules = "1.7.0"
 coil = "3.5.0"
 hilt = "2.60.1"
 junit4 = "4.13.2"
@@ -51,6 +53,7 @@ accompanist-permissions = { group = "com.google.accompanist", name = "accompanis
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "androidxActivity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
+androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "androidxBiometric" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidx-compose-icons = { module = "androidx.compose.material:material-icons-extended" }
 androidx-compose-material-iconsExtended = { group = "androidx.compose.material", name = "material-icons-extended" }
@@ -87,6 +90,7 @@ androidx-room-runtime = { group = "androidx.room", name = "room-runtime", versio
 androidx-room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }
 androidx-test-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidxTestExt" }
+androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidxTestRules" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
 github-albfernandez-juniversalchardet = { group="com.github.albfernandez", name = "juniversalchardet", version.ref="universalChardet" }


### PR DESCRIPTION
Vault users can now choose biometric unlock after confirming their PIN. Enabling it requires a successful system biometric scan, and **Vault settings → Unlock with biometrics** lets them disable it or enable it later. The choice persists, PIN fallback remains available, and existing vaults stay PIN-only until the user opts in. Both direct vault setup and first-time Hide setup offer the choice.

The change also simplifies vault move/reservation handling with Kotlin `Result`, shares the selection action component, and removes unused PIN configuration. Cancellation cleanup and reservation visibility are preserved. Navigation callbacks refresh after activity recreation, and the vault device-test FileProvider is configured correctly. Vault entry remains a long press on the app title.

### Validation

- `./gradlew assembleDebug test ktlintCheck :app:assembleDebugAndroidTest` passed; **170 local tests** passed with zero failures, errors, or skips.
- Direct ktlint checks passed on changed Kotlin sources because the repository's ktlint task skips Android sources with the current AGP/plugin combination.
- **10 vault repository device tests** and **2 activity-recreation navigation tests** passed on a disposable **Pixel 6a emulator, API 37**.
- Emulator flows passed: PIN setup and rejection, hide/playback/unhide with matching restored-file SHA-256, no enrolled biometrics, biometric opt-in in both creation paths, setup skip, rejected scans, cancellation, retry, confirmation across rotation, app restart, disabling, and PIN fallback with a hidden video. No app crashes recorded.
- Installed the verified debug APK on the connected CPH2689 device; physical-device interaction testing was not performed.

### Screenshots

Pixel 6a emulator, API 37. The system biometric dialog is excluded from screenshots on this emulator; its success, rejection, cancellation, and rotation behavior was verified on-device.

| Before: PIN-only entry | After: optional biometric setup | After: Vault settings |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/anilbeesetti/nextplayer/caab19f8706535c5ab2b33ccf72f52fc15f3c208/fastlane/metadata/review/vault/before.png" width="240" alt="Vault PIN entry before this change" /> | <img src="https://raw.githubusercontent.com/anilbeesetti/nextplayer/caab19f8706535c5ab2b33ccf72f52fc15f3c208/fastlane/metadata/review/vault/setup.png" width="240" alt="Optional biometric setup after PIN confirmation" /> | <img src="https://raw.githubusercontent.com/anilbeesetti/nextplayer/caab19f8706535c5ab2b33ccf72f52fc15f3c208/fastlane/metadata/review/vault/settings.png" width="240" alt="Vault settings biometric unlock switch" /> |
