### PR TITLE
Add playback history to More

### DIFF
--- a/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/navigation/MoreNavigation.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/navigation/MoreNavigation.kt
@@ -3,19 +3,25 @@ package dev.anilbeesetti.nextplayer.feature.more.navigation
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
+import dev.anilbeesetti.nextplayer.feature.more.screens.history.HistoryScreen
 import dev.anilbeesetti.nextplayer.feature.more.screens.more.MoreScreen
 import kotlinx.serialization.Serializable
 
 @Serializable
 object MoreRoute : NavKey
 
+@Serializable
+object HistoryRoute : NavKey
+
 fun EntryProviderScope<NavKey>.moreEntry(
+    onHistoryClick: () -> Unit,
     onPlayVideo: (String) -> Unit,
     onSettingsClick: () -> Unit,
     onVaultClick: () -> Unit,
 ) {
     entry<MoreRoute> {
         MoreScreen(
+            onHistoryClick = onHistoryClick,
             onPlayVideo = onPlayVideo,
             onSettingsClick = onSettingsClick,
             onVaultClick = onVaultClick,
@@ -23,6 +29,22 @@ fun EntryProviderScope<NavKey>.moreEntry(
     }
 }
 
+fun EntryProviderScope<NavKey>.historyEntry(
+    onNavigateUp: () -> Unit,
+    onPlayVideo: (String) -> Unit,
+) {
+    entry<HistoryRoute> {
+        HistoryScreen(
+            onNavigateUp = onNavigateUp,
+            onPlayVideo = onPlayVideo,
+        )
+    }
+}
+
 fun NavBackStack<NavKey>.navigateToMore() {
     add(MoreRoute)
+}
+
+fun NavBackStack<NavKey>.navigateToHistory() {
+    add(HistoryRoute)
 }

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/history/HistoryScreen.kt
@@ -1,0 +1,149 @@
+package dev.anilbeesetti.nextplayer.feature.more.screens.history
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.anilbeesetti.nextplayer.core.ui.R
+import dev.anilbeesetti.nextplayer.core.ui.base.DataState
+import dev.anilbeesetti.nextplayer.core.ui.components.NextDialog
+import dev.anilbeesetti.nextplayer.core.ui.components.NextTopAppBar
+import dev.anilbeesetti.nextplayer.core.ui.components.tvFocusRing
+import dev.anilbeesetti.nextplayer.core.ui.designsystem.NextIcons
+import dev.anilbeesetti.nextplayer.core.ui.extensions.copy
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.CenterCircularProgressBar
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.VideoListItem
+
+@Composable
+fun HistoryScreen(
+    onNavigateUp: () -> Unit,
+    onPlayVideo: (String) -> Unit,
+    viewModel: HistoryViewModel = hiltViewModel(),
+) {
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+
+    HistoryScreenContent(
+        uiState = uiState,
+        onNavigateUp = onNavigateUp,
+        onPlayVideo = onPlayVideo,
+        onClearHistory = viewModel::clearHistory,
+    )
+}
+
+@Composable
+internal fun HistoryScreenContent(
+    uiState: HistoryUiState,
+    onNavigateUp: () -> Unit,
+    onPlayVideo: (String) -> Unit,
+    onClearHistory: () -> Unit,
+) {
+    var showClearConfirmation by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            NextTopAppBar(
+                title = stringResource(R.string.history),
+                navigationIcon = {
+                    FilledTonalIconButton(
+                        onClick = onNavigateUp,
+                        modifier = Modifier.tvFocusRing(),
+                    ) {
+                        Icon(
+                            imageVector = NextIcons.ArrowBack,
+                            contentDescription = stringResource(R.string.navigate_up),
+                        )
+                    }
+                },
+                actions = {
+                    TextButton(
+                        enabled = uiState.history.result.orEmpty().isNotEmpty(),
+                        onClick = { showClearConfirmation = true },
+                        modifier = Modifier.tvFocusRing(),
+                    ) {
+                        Text(stringResource(R.string.clear_all))
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+    ) { scaffoldPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(scaffoldPadding.copy(bottom = 0.dp))
+                .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+                .background(MaterialTheme.colorScheme.background),
+        ) {
+            when (val history = uiState.history) {
+                is DataState.Loading -> CenterCircularProgressBar()
+                is DataState.Error -> Text(
+                    text = history.value.message.orEmpty(),
+                    modifier = Modifier.padding(16.dp),
+                    color = MaterialTheme.colorScheme.error,
+                )
+                is DataState.Success -> LazyColumn(
+                    contentPadding = PaddingValues(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    itemsIndexed(history.value, key = { _, video -> video.uriString }) { index, video ->
+                        VideoListItem(
+                            video = video,
+                            isRecentlyPlayedVideo = false,
+                            preferences = uiState.preferences,
+                            isFirstItem = index == 0,
+                            isLastItem = index == history.value.lastIndex,
+                            onClick = { onPlayVideo(video.uriString) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showClearConfirmation) {
+        NextDialog(
+            onDismissRequest = { showClearConfirmation = false },
+            title = { Text(stringResource(R.string.clear_history)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onClearHistory()
+                        showClearConfirmation = false
+                    },
+                ) {
+                    Text(stringResource(R.string.clear_all))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showClearConfirmation = false }) {
+                    Text(stringResource(R.string.cancel))
+                }
+            },
+            content = { Text(stringResource(R.string.clear_history_confirmation)) },
+        )
+    }
+}

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/history/HistoryViewModel.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/history/HistoryViewModel.kt
@@ -1,4 +1,4 @@
-package dev.anilbeesetti.nextplayer.feature.more.screens.more
+package dev.anilbeesetti.nextplayer.feature.more.screens.history
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -14,47 +14,29 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class MoreViewModel @Inject constructor(
-    mediaRepository: MediaRepository,
+class HistoryViewModel @Inject constructor(
+    private val mediaRepository: MediaRepository,
     preferencesRepository: PreferencesRepository,
 ) : ViewModel() {
-    val uiState: StateFlow<MoreUiState> = combine(
+    val uiState: StateFlow<HistoryUiState> = combine(
         mediaRepository.observePlaybackHistory()
             .map<List<Video>, DataState<List<Video>>> { DataState.Success(it) }
             .catch { emit(DataState.Error(it)) },
         preferencesRepository.applicationPreferences,
     ) { history, preferences ->
-        MoreUiState(history = history, preferences = preferences)
-    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), MoreUiState())
+        HistoryUiState(history = history, preferences = preferences)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), HistoryUiState())
 
-    fun onAction(action: MoreAction, output: Output) {
-        when (action) {
-            MoreAction.OpenHistory -> output.openHistory()
-            is MoreAction.PlayVideo -> output.playVideo(action.uri)
-            MoreAction.OpenSettings -> output.openSettings()
-            MoreAction.OpenVault -> output.openVault()
-        }
+    fun clearHistory() {
+        viewModelScope.launch { mediaRepository.clearPlaybackHistory() }
     }
-
-    data class Output(
-        val openHistory: () -> Unit,
-        val playVideo: (String) -> Unit,
-        val openSettings: () -> Unit,
-        val openVault: () -> Unit,
-    )
 }
 
-data class MoreUiState(
+data class HistoryUiState(
     val history: DataState<List<Video>> = DataState.Loading,
     val preferences: ApplicationPreferences = ApplicationPreferences(),
 )
-
-sealed interface MoreAction {
-    data object OpenHistory : MoreAction
-    data class PlayVideo(val uri: String) : MoreAction
-    data object OpenSettings : MoreAction
-    data object OpenVault : MoreAction
-}

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/more/MoreScreen.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/more/MoreScreen.kt
@@ -7,23 +7,30 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -33,23 +40,29 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import dev.anilbeesetti.nextplayer.core.model.ApplicationPreferences
 import dev.anilbeesetti.nextplayer.core.ui.R
+import dev.anilbeesetti.nextplayer.core.model.Video
 import dev.anilbeesetti.nextplayer.core.ui.components.BindTopLevelFab
 import dev.anilbeesetti.nextplayer.core.ui.components.LocalNavigationBottomPadding
 import dev.anilbeesetti.nextplayer.core.ui.components.NextTopAppBar
 import dev.anilbeesetti.nextplayer.core.ui.components.TopLevelFabKey
 import dev.anilbeesetti.nextplayer.core.ui.designsystem.NextIcons
 import dev.anilbeesetti.nextplayer.core.ui.extensions.copy
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.VideoGridItem
 
 @Composable
 fun MoreScreen(
+    onHistoryClick: () -> Unit,
     onPlayVideo: (String) -> Unit,
     onSettingsClick: () -> Unit,
     onVaultClick: () -> Unit,
     viewModel: MoreViewModel = hiltViewModel(),
 ) {
-    val output = remember(onPlayVideo, onSettingsClick, onVaultClick) {
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    val output = remember(onHistoryClick, onPlayVideo, onSettingsClick, onVaultClick) {
         MoreViewModel.Output(
+            openHistory = onHistoryClick,
             playVideo = onPlayVideo,
             openSettings = onSettingsClick,
             openVault = onVaultClick,
@@ -57,12 +70,14 @@ fun MoreScreen(
     }
 
     MoreScreenContent(
+        uiState = uiState,
         onAction = { viewModel.onAction(it, output) },
     )
 }
 
 @Composable
 internal fun MoreScreenContent(
+    uiState: MoreUiState,
     onAction: (MoreAction) -> Unit,
 ) {
     BindTopLevelFab(TopLevelFabKey.MORE, NextIcons.Settings) { onAction(MoreAction.OpenSettings) }
@@ -126,7 +141,51 @@ internal fun MoreScreenContent(
                     }
 
                 }
+                HistorySection(
+                    history = uiState.history.result.orEmpty().take(10),
+                    preferences = uiState.preferences,
+                    onMoreClick = { onAction(MoreAction.OpenHistory) },
+                    onVideoClick = { onAction(MoreAction.PlayVideo(it.uriString)) },
+                )
+            }
+        }
+    }
+}
 
+@Composable
+private fun HistorySection(
+    history: List<Video>,
+    preferences: ApplicationPreferences,
+    onMoreClick: () -> Unit,
+    onVideoClick: (Video) -> Unit,
+) {
+    if (history.isEmpty()) return
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(R.string.history),
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.padding(start = 8.dp).weight(1f),
+            )
+            IconButton(onClick = onMoreClick) {
+                Icon(imageVector = NextIcons.ArrowForward, contentDescription = stringResource(R.string.history))
+            }
+        }
+        LazyRow(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+            items(history, key = { it.uriString }) { video ->
+                VideoGridItem(
+                    video = video,
+                    isRecentlyPlayedVideo = false,
+                    textStyle = MaterialTheme.typography.bodySmall,
+                    preferences = preferences,
+                    modifier = Modifier.width(140.dp),
+                    onClick = { onVideoClick(video) },
+                )
             }
         }
     }
@@ -135,5 +194,5 @@ internal fun MoreScreenContent(
 @Preview
 @Composable
 private fun MoreScreenContentPreview() {
-    MoreScreenContent(onAction = {})
+    MoreScreenContent(uiState = MoreUiState(), onAction = {})
 }

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/MoreNavGraph.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/MoreNavGraph.kt
@@ -5,7 +5,9 @@ import androidx.core.net.toUri
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
+import dev.anilbeesetti.nextplayer.feature.more.navigation.historyEntry
 import dev.anilbeesetti.nextplayer.feature.more.navigation.moreEntry
+import dev.anilbeesetti.nextplayer.feature.more.navigation.navigateToHistory
 import dev.anilbeesetti.nextplayer.feature.videopicker.navigation.navigateToVault
 import dev.anilbeesetti.nextplayer.feature.videopicker.navigation.vaultEntry
 import dev.anilbeesetti.nextplayer.settings.navigation.navigateToSettings
@@ -15,9 +17,15 @@ fun EntryProviderScope<NavKey>.moreNavGraph(
     backStack: NavBackStack<NavKey>,
 ) {
     moreEntry(
+        onHistoryClick = backStack::navigateToHistory,
         onPlayVideo = { context.startPlayback(it.toUri()) },
         onSettingsClick = backStack::navigateToSettings,
         onVaultClick = backStack::navigateToVault,
+    )
+
+    historyEntry(
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
+        onPlayVideo = { context.startPlayback(it.toUri()) },
     )
 
     vaultEntry(

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalMediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalMediaRepository.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.os.Environment
 import androidx.core.net.toUri
 import dagger.hilt.android.qualifiers.ApplicationContext
+import dev.anilbeesetti.nextplayer.core.common.Utils
 import dev.anilbeesetti.nextplayer.core.common.extensions.mapAsync
 import dev.anilbeesetti.nextplayer.core.data.mappers.toAudioStreamInfo
 import dev.anilbeesetti.nextplayer.core.data.mappers.toFolder
@@ -21,6 +22,7 @@ import dev.anilbeesetti.nextplayer.core.model.Folder
 import dev.anilbeesetti.nextplayer.core.model.MediaInfo
 import dev.anilbeesetti.nextplayer.core.model.Video
 import io.github.anilbeesetti.nextlib.mediainfo.MediaInfoBuilder
+import java.util.Date
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -28,6 +30,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
+import kotlin.math.absoluteValue
 import javax.inject.Inject
 
 class LocalMediaRepository @Inject constructor(
@@ -63,6 +66,18 @@ class LocalMediaRepository @Inject constructor(
         }
     }
 
+    override fun observePlaybackHistory(): Flow<List<Video>> {
+        return combine(mediaService.observeVideos(), mediumStateDao.getAll()) { mediaVideos, mediumStates ->
+            val videosByUri = mediaVideos.associateBy { it.uri.toString() }
+            mediumStates
+                .filter { it.lastPlayedTime != null }
+                .sortedByDescending { it.lastPlayedTime }
+                .map { state ->
+                    videosByUri[state.uriString]?.toVideo(state) ?: state.toHistoryVideo()
+                }
+        }
+    }
+
     override suspend fun getVideoByUri(uri: String): Video? = coroutineScope {
         val mediaVideoDeferred = async { mediaService.findVideo(uri.toUri()) }
         val mediaStateDeferred = async { mediumStateDao.get(uri) }
@@ -90,12 +105,17 @@ class LocalMediaRepository @Inject constructor(
         return@withContext result
     }
 
-    override suspend fun updateMediumLastPlayedTime(uri: String, lastPlayedTime: Long) {
+    override suspend fun clearPlaybackHistory() {
+        mediumStateDao.clearPlaybackHistory()
+    }
+
+    override suspend fun updateMediumLastPlayedTime(uri: String, lastPlayedTime: Long, duration: Long?) {
         val stateEntity = mediumStateDao.get(uri) ?: MediumStateEntity(uriString = uri)
 
         mediumStateDao.upsert(
             mediumState = stateEntity.copy(
                 lastPlayedTime = lastPlayedTime,
+                duration = duration ?: stateEntity.duration,
             ),
         )
     }
@@ -190,4 +210,24 @@ class LocalMediaRepository @Inject constructor(
             ),
         )
     }
+}
+
+private fun MediumStateEntity.toHistoryVideo(): Video {
+    val uri = uriString.toUri()
+    val name = uri.lastPathSegment?.substringAfterLast('/')
+        ?: uri.host
+        ?: uriString
+    return Video(
+        id = uriString.hashCode().toLong().absoluteValue,
+        path = uriString,
+        uriString = uriString,
+        nameWithExtension = name,
+        duration = duration ?: 0,
+        width = 0,
+        height = 0,
+        size = 0,
+        formattedDuration = duration?.let(Utils::formatDurationMillis).orEmpty(),
+        playbackPosition = playbackPosition,
+        lastPlayedAt = lastPlayedTime?.let(::Date),
+    )
 }

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/MediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/MediaRepository.kt
@@ -31,6 +31,8 @@ interface MediaRepository {
      */
     fun observeVideos(folderPath: String? = null): Flow<List<Video>>
 
+    fun observePlaybackHistory(): Flow<List<Video>>
+
     /**
      * Fetches all unique folders containing videos under the given path (one-shot).
      *
@@ -50,7 +52,8 @@ interface MediaRepository {
     suspend fun getVideoByUri(uri: String): Video?
     suspend fun getVideoState(uri: String): VideoState?
     suspend fun getMediaInfo(uri: String): MediaInfo?
-    suspend fun updateMediumLastPlayedTime(uri: String, lastPlayedTime: Long)
+    suspend fun clearPlaybackHistory()
+    suspend fun updateMediumLastPlayedTime(uri: String, lastPlayedTime: Long, duration: Long? = null)
     suspend fun updateMediumPosition(uri: String, position: Long)
     suspend fun updateMediumPlaybackSpeed(uri: String, playbackSpeed: Float)
     suspend fun updateMediumAudioTrack(uri: String, audioTrackIndex: Int)

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/fake/FakeMediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/fake/FakeMediaRepository.kt
@@ -36,6 +36,10 @@ class FakeMediaRepository : MediaRepository {
         return videos.filter { folderPath == null || it.path.startsWith(folderPath) }
     }
 
+    override fun observePlaybackHistory(): Flow<List<Video>> {
+        return updates.map { videos.filter { it.lastPlayedAt != null }.sortedByDescending { it.lastPlayedAt?.time } }
+    }
+
     override suspend fun getVideoByUri(uri: String): Video? {
         return videos.find { it.uriString == uri }
     }
@@ -52,7 +56,10 @@ class FakeMediaRepository : MediaRepository {
         return null
     }
 
-    override suspend fun updateMediumLastPlayedTime(uri: String, lastPlayedTime: Long) {
+    override suspend fun clearPlaybackHistory() {
+    }
+
+    override suspend fun updateMediumLastPlayedTime(uri: String, lastPlayedTime: Long, duration: Long?) {
     }
 
     override suspend fun updateMediumPosition(uri: String, position: Long) {

--- a/core/database/schemas/dev.anilbeesetti.nextplayer.core.database.MediaDatabase/11.json
+++ b/core/database/schemas/dev.anilbeesetti.nextplayer.core.database.MediaDatabase/11.json
@@ -1,0 +1,410 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 11,
+    "identityHash": "84beb9e585dab05223273c6b481d8320",
+    "entities": [
+      {
+        "tableName": "media_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uri` TEXT NOT NULL, `playback_position` INTEGER NOT NULL, `audio_track_index` INTEGER, `subtitle_track_index` INTEGER, `playback_speed` REAL, `last_played_time` INTEGER, `duration` INTEGER, `external_subs` TEXT NOT NULL, `video_scale` REAL NOT NULL, `subtitle_delay` INTEGER NOT NULL, `subtitle_speed` REAL NOT NULL, PRIMARY KEY(`uri`))",
+        "fields": [
+          {
+            "fieldPath": "uriString",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackPosition",
+            "columnName": "playback_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioTrackIndex",
+            "columnName": "audio_track_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "subtitleTrackIndex",
+            "columnName": "subtitle_track_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playback_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lastPlayedTime",
+            "columnName": "last_played_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalSubs",
+            "columnName": "external_subs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoScale",
+            "columnName": "video_scale",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitleDelayMilliseconds",
+            "columnName": "subtitle_delay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitleSpeed",
+            "columnName": "subtitle_speed",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_state_uri",
+            "unique": true,
+            "columnNames": [
+              "uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_media_state_uri` ON `${TABLE_NAME}` (`uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "hidden_video",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `vault_path` TEXT NOT NULL, `original_path` TEXT NOT NULL, `display_name` TEXT NOT NULL, `duration` INTEGER NOT NULL, `size` INTEGER NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `hidden_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vaultPath",
+            "columnName": "vault_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalPath",
+            "columnName": "original_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hidden_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_hidden_video_vault_path",
+            "unique": true,
+            "columnNames": [
+              "vault_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_hidden_video_vault_path` ON `${TABLE_NAME}` (`vault_path`)"
+          }
+        ]
+      },
+      {
+        "tableName": "network_connection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `protocol` TEXT NOT NULL, `host` TEXT NOT NULL, `port` INTEGER, `path` TEXT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `use_https` INTEGER NOT NULL, `authentication` TEXT NOT NULL DEFAULT 'PASSWORD', `private_key_file_name` TEXT NOT NULL DEFAULT '', `private_key_passphrase` TEXT NOT NULL DEFAULT '', `host_key_fingerprint` TEXT NOT NULL DEFAULT '', `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "protocol",
+            "columnName": "protocol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useHttps",
+            "columnName": "use_https",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authentication",
+            "columnName": "authentication",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'PASSWORD'"
+          },
+          {
+            "fieldPath": "privateKeyFileName",
+            "columnName": "private_key_file_name",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "privateKeyPassphrase",
+            "columnName": "private_key_passphrase",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "hostKeyFingerprint",
+            "columnName": "host_key_fingerprint",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `source` TEXT, `created_at` INTEGER NOT NULL, `last_refreshed_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastRefreshedAt",
+            "columnName": "last_refreshed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `uri` TEXT NOT NULL, `position` INTEGER NOT NULL, `title` TEXT, `tvg_logo` TEXT, `duration` INTEGER NOT NULL, `group_title` TEXT, `last_played_at` INTEGER, PRIMARY KEY(`playlist_id`, `uri`), FOREIGN KEY(`playlist_id`) REFERENCES `playlist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tvgLogo",
+            "columnName": "tvg_logo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupTitle",
+            "columnName": "group_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "uri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_item_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_item_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_playlist_item_playlist_id_position",
+            "unique": true,
+            "columnNames": [
+              "playlist_id",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playlist_item_playlist_id_position` ON `${TABLE_NAME}` (`playlist_id`, `position`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '84beb9e585dab05223273c6b481d8320')"
+    ]
+  }
+}

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/DatabaseModule.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/DatabaseModule.kt
@@ -32,6 +32,7 @@ object DatabaseModule {
             MediaDatabase.MIGRATION_7_8,
             MediaDatabase.MIGRATION_8_9,
             MediaDatabase.MIGRATION_9_10,
+            MediaDatabase.MIGRATION_10_11,
         )
         fallbackToDestructiveMigration(false)
     }.build()

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/MediaDatabase.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/MediaDatabase.kt
@@ -22,7 +22,7 @@ import dev.anilbeesetti.nextplayer.core.database.entities.PlaylistItemEntity
         PlaylistEntity::class,
         PlaylistItemEntity::class,
     ],
-    version = 10,
+    version = 11,
     exportSchema = true,
 )
 abstract class MediaDatabase : RoomDatabase() {
@@ -315,6 +315,12 @@ abstract class MediaDatabase : RoomDatabase() {
                     "ALTER TABLE `playlist_item` ADD COLUMN `duration` INTEGER NOT NULL DEFAULT -1",
                 )
                 db.execSQL("ALTER TABLE `playlist_item` ADD COLUMN `group_title` TEXT")
+            }
+        }
+
+        val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `media_state` ADD COLUMN `duration` INTEGER")
             }
         }
     }

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/dao/MediumStateDao.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/dao/MediumStateDao.kt
@@ -24,6 +24,9 @@ interface MediumStateDao {
     @Query("SELECT * FROM media_state")
     fun getAll(): Flow<List<MediumStateEntity>>
 
+    @Query("UPDATE media_state SET last_played_time = NULL")
+    suspend fun clearPlaybackHistory()
+
     @Query("DELETE FROM media_state WHERE uri in (:uris)")
     suspend fun delete(uris: List<String>)
 }

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/entities/MediumStateEntity.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/entities/MediumStateEntity.kt
@@ -25,6 +25,8 @@ data class MediumStateEntity(
     val playbackSpeed: Float? = null,
     @ColumnInfo(name = "last_played_time")
     val lastPlayedTime: Long? = null,
+    @ColumnInfo(name = "duration")
+    val duration: Long? = null,
     @ColumnInfo(name = "external_subs")
     val externalSubs: String = "",
     @ColumnInfo(name = "video_scale")

--- a/core/ui/src/main/java/dev/anilbeesetti/nextplayer/core/ui/designsystem/NextIcons.kt
+++ b/core/ui/src/main/java/dev/anilbeesetti/nextplayer/core/ui/designsystem/NextIcons.kt
@@ -2,6 +2,7 @@ package dev.anilbeesetti.nextplayer.core.ui.designsystem
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.automirrored.rounded.ArrowForward
 import androidx.compose.material.icons.automirrored.rounded.CompareArrows
 import androidx.compose.material.icons.automirrored.rounded.DriveFileMove
 import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
@@ -96,6 +97,7 @@ object NextIcons {
     val Add = Icons.Rounded.Add
     val Appearance = Icons.Rounded.Palette
     val ArrowBack = Icons.AutoMirrored.Rounded.ArrowBack
+    val ArrowForward = Icons.AutoMirrored.Rounded.ArrowForward
     val ArrowDownward = Icons.Rounded.ArrowDownward
     val ArrowUpward = Icons.Rounded.ArrowUpward
     val Audio = Icons.Rounded.Audiotrack

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="select_audio_track">Select audio track</string>
     <string name="select_subtitle_track">Select subtitle track</string>
     <string name="settings">Settings</string>
+    <string name="history">History</string>
     <string name="size">Size</string>
     <string name="sort">Sort</string>
     <string name="title">Title</string>
@@ -294,6 +295,8 @@
     <string name="recent_searches">Recent searches</string>
     <string name="popular_folders">Popular folders</string>
     <string name="clear_history">Clear history</string>
+    <string name="clear_all">Clear all</string>
+    <string name="clear_history_confirmation">Remove all watched videos from history?</string>
     <string name="no_results_found">No results found</string>
     <string name="search_results">Search results</string>
     <string name="now_playing">Now playing</string>

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
@@ -355,6 +355,7 @@ class PlayerService : MediaSessionService() {
                         mediaRepository.updateMediumLastPlayedTime(
                             uri = it.currentMediaItem?.mediaId ?: return@launch,
                             lastPlayedTime = System.currentTimeMillis(),
+                            duration = it.duration.validDurationOrNull(),
                         )
                     }
                 }
@@ -762,6 +763,8 @@ class PlayerService : MediaSessionService() {
         subtitleCacheDir.deleteFiles()
         serviceScope.cancel()
     }
+
+    private fun Long.validDurationOrNull(): Long? = takeIf { it != C.TIME_UNSET && it >= 0 }
 
     private suspend fun updatedMediaItemsWithMetadata(
         mediaItems: List<MediaItem>,

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/VideoItem.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/VideoItem.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewLightDark
@@ -86,7 +87,7 @@ fun VideoItem(
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun VideoListItem(
+fun VideoListItem(
     video: Video,
     isRecentlyPlayedVideo: Boolean,
     preferences: ApplicationPreferences,
@@ -165,11 +166,12 @@ private fun VideoListItem(
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
-private fun VideoGridItem(
+fun VideoGridItem(
+    modifier: Modifier = Modifier,
     video: Video,
     isRecentlyPlayedVideo: Boolean,
     preferences: ApplicationPreferences,
-    modifier: Modifier = Modifier,
+    textStyle: TextStyle = MaterialTheme.typography.titleMedium,
     isFirstItem: Boolean = false,
     isLastItem: Boolean = false,
     selected: Boolean = false,
@@ -209,7 +211,7 @@ private fun VideoGridItem(
                 Text(
                     text = if (preferences.showExtensionField) video.nameWithExtension else video.displayName,
                     maxLines = 2,
-                    style = MaterialTheme.typography.titleMedium,
+                    style = textStyle,
                     overflow = TextOverflow.Ellipsis,
                     textAlign = TextAlign.Center,
                     color = if (isRecentlyPlayedVideo && preferences.markLastPlayedMedia) {


### PR DESCRIPTION
Add playback history to More, with a preview of the ten latest videos, a full history screen, replay, and a clear-history confirmation. Build fallback history items from saved playback state when MediaStore metadata is unavailable, including stream entries.

Persist valid playback duration in database version 11, migrate existing version-10 databases without clearing playback state, and clear only last-played timestamps when the user clears history. Expose the reusable video grid item for the history preview.

Validation: `./gradlew assembleDebug test ktlintCheck` passes; 171 local tests, zero failures/errors.

Split from local `refactor-nav` at `02c0f369`. Based on #1908; review against `codex/refactor-nav-layout`. Trash is a separate follow-up PR.

Stack / merge order: #1907 → #1908 → #1909 → #1910. Each child targets its preceding PR branch so GitHub shows only that step. Merge in this order; retarget/rebase the next child onto `main` after its parent merges as needed.

Review note: the existing media synchronizer still prunes saved state for missing `content://` items. The fallback history item does not change that existing cleanup policy.

Emulator verification: disposable Pixel 6a, Android 17/API 37, arm64/16 KB pages. Confirmed version-10 to version-11 database upgrade, played the generated 12-second clip, opened its More preview and full History screen, and cleared history through confirmation. A database inspection after clearing showed the media-state row and 12000 ms duration retained with `last_played_time = NULL`. UI automation recovered after rebooting the isolated emulator.

Screenshots — More before history, populated preview, and History after clearing:

<img src="https://raw.githubusercontent.com/anilbeesetti/nextplayer/75edde6fa7c4ee9ddbd3223ab576bf40f2162121/fastlane/metadata/android/en-US/images/refactor-nav-review/navigation-more.png" width="260" /> <img src="https://raw.githubusercontent.com/anilbeesetti/nextplayer/75edde6fa7c4ee9ddbd3223ab576bf40f2162121/fastlane/metadata/android/en-US/images/refactor-nav-review/history-more.png" width="260" /> <img src="https://raw.githubusercontent.com/anilbeesetti/nextplayer/75edde6fa7c4ee9ddbd3223ab576bf40f2162121/fastlane/metadata/android/en-US/images/refactor-nav-review/history-cleared.png" width="260" />
