### PR TITLE
Add video trash and restore actions

### DIFF
--- a/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/navigation/MoreNavigation.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/navigation/MoreNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavKey
 import dev.anilbeesetti.nextplayer.feature.more.screens.history.HistoryScreen
 import dev.anilbeesetti.nextplayer.feature.more.screens.more.MoreScreen
+import dev.anilbeesetti.nextplayer.feature.more.screens.trash.TrashScreen
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -13,10 +14,14 @@ object MoreRoute : NavKey
 @Serializable
 object HistoryRoute : NavKey
 
+@Serializable
+object TrashRoute : NavKey
+
 fun EntryProviderScope<NavKey>.moreEntry(
     onHistoryClick: () -> Unit,
     onPlayVideo: (String) -> Unit,
     onSettingsClick: () -> Unit,
+    onTrashClick: () -> Unit,
     onVaultClick: () -> Unit,
 ) {
     entry<MoreRoute> {
@@ -24,6 +29,7 @@ fun EntryProviderScope<NavKey>.moreEntry(
             onHistoryClick = onHistoryClick,
             onPlayVideo = onPlayVideo,
             onSettingsClick = onSettingsClick,
+            onTrashClick = onTrashClick,
             onVaultClick = onVaultClick,
         )
     }
@@ -41,10 +47,26 @@ fun EntryProviderScope<NavKey>.historyEntry(
     }
 }
 
+fun EntryProviderScope<NavKey>.trashEntry(
+    onNavigateUp: () -> Unit,
+    onPlayVideo: (String) -> Unit,
+) {
+    entry<TrashRoute> {
+        TrashScreen(
+            onNavigateUp = onNavigateUp,
+            onPlayVideo = onPlayVideo,
+        )
+    }
+}
+
 fun NavBackStack<NavKey>.navigateToMore() {
     add(MoreRoute)
 }
 
 fun NavBackStack<NavKey>.navigateToHistory() {
     add(HistoryRoute)
+}
+
+fun NavBackStack<NavKey>.navigateToTrash() {
+    add(TrashRoute)
 }

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/more/MoreScreen.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/more/MoreScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import dev.anilbeesetti.nextplayer.core.model.ApplicationPreferences
 import dev.anilbeesetti.nextplayer.core.ui.R
+import dev.anilbeesetti.nextplayer.core.media.services.MediaOperationsService
 import dev.anilbeesetti.nextplayer.core.model.Video
 import dev.anilbeesetti.nextplayer.core.ui.components.BindTopLevelFab
 import dev.anilbeesetti.nextplayer.core.ui.components.LocalNavigationBottomPadding
@@ -56,15 +57,17 @@ fun MoreScreen(
     onHistoryClick: () -> Unit,
     onPlayVideo: (String) -> Unit,
     onSettingsClick: () -> Unit,
+    onTrashClick: () -> Unit,
     onVaultClick: () -> Unit,
     viewModel: MoreViewModel = hiltViewModel(),
 ) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
-    val output = remember(onHistoryClick, onPlayVideo, onSettingsClick, onVaultClick) {
+    val output = remember(onHistoryClick, onPlayVideo, onSettingsClick, onTrashClick, onVaultClick) {
         MoreViewModel.Output(
             openHistory = onHistoryClick,
             playVideo = onPlayVideo,
             openSettings = onSettingsClick,
+            openTrash = onTrashClick,
             openVault = onVaultClick,
         )
     }
@@ -139,7 +142,21 @@ internal fun MoreScreenContent(
                         Spacer(modifier = Modifier.size(8.dp))
                         Text(text = stringResource(R.string.pick_file))
                     }
-
+                    if (MediaOperationsService.supportsTrash()) {
+                        FilledTonalButton(
+                            modifier = Modifier.weight(1f),
+                            onClick = { onAction(MoreAction.OpenTrash) },
+                        ) {
+                            Icon(
+                                imageVector = NextIcons.Delete,
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp),
+                            )
+                            Spacer(modifier = Modifier.size(8.dp))
+                            Text(text = stringResource(R.string.trash))
+                        }
+                        Spacer(modifier = Modifier.weight(1f))
+                    }
                 }
                 HistorySection(
                     history = uiState.history.result.orEmpty().take(10),

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/more/MoreViewModel.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/more/MoreViewModel.kt
@@ -35,6 +35,7 @@ class MoreViewModel @Inject constructor(
             MoreAction.OpenHistory -> output.openHistory()
             is MoreAction.PlayVideo -> output.playVideo(action.uri)
             MoreAction.OpenSettings -> output.openSettings()
+            MoreAction.OpenTrash -> output.openTrash()
             MoreAction.OpenVault -> output.openVault()
         }
     }
@@ -43,6 +44,7 @@ class MoreViewModel @Inject constructor(
         val openHistory: () -> Unit,
         val playVideo: (String) -> Unit,
         val openSettings: () -> Unit,
+        val openTrash: () -> Unit,
         val openVault: () -> Unit,
     )
 }
@@ -56,5 +58,6 @@ sealed interface MoreAction {
     data object OpenHistory : MoreAction
     data class PlayVideo(val uri: String) : MoreAction
     data object OpenSettings : MoreAction
+    data object OpenTrash : MoreAction
     data object OpenVault : MoreAction
 }

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/trash/TrashScreen.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/trash/TrashScreen.kt
@@ -1,0 +1,171 @@
+package dev.anilbeesetti.nextplayer.feature.more.screens.trash
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.anilbeesetti.nextplayer.core.ui.R
+import dev.anilbeesetti.nextplayer.core.ui.base.DataState
+import dev.anilbeesetti.nextplayer.core.ui.components.NextDialog
+import dev.anilbeesetti.nextplayer.core.ui.components.NextTopAppBar
+import dev.anilbeesetti.nextplayer.core.ui.components.tvFocusRing
+import dev.anilbeesetti.nextplayer.core.ui.designsystem.NextIcons
+import dev.anilbeesetti.nextplayer.core.ui.extensions.copy
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.CenterCircularProgressBar
+import dev.anilbeesetti.nextplayer.feature.videopicker.composables.VideoListItem
+import dev.anilbeesetti.nextplayer.feature.videopicker.state.SelectionItem
+import dev.anilbeesetti.nextplayer.feature.videopicker.state.rememberSelectionManager
+import dev.anilbeesetti.nextplayer.feature.videopicker.state.toSelectedVideo
+
+@Composable
+fun TrashScreen(
+    onNavigateUp: () -> Unit,
+    onPlayVideo: (String) -> Unit,
+    viewModel: TrashViewModel = hiltViewModel(),
+) {
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    TrashScreenContent(
+        uiState = uiState,
+        onNavigateUp = onNavigateUp,
+        onPlayVideo = onPlayVideo,
+        onRestore = viewModel::restore,
+        onDelete = viewModel::deletePermanently,
+    )
+}
+
+@Composable
+internal fun TrashScreenContent(
+    uiState: TrashUiState,
+    onNavigateUp: () -> Unit,
+    onPlayVideo: (String) -> Unit,
+    onRestore: (Set<SelectionItem>) -> Unit,
+    onDelete: (Set<SelectionItem>) -> Unit,
+) {
+    val selectionManager = rememberSelectionManager()
+    var showDeleteConfirmation by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            NextTopAppBar(
+                title = if (selectionManager.isInSelectionMode) {
+                    stringResource(R.string.m_n_selected, selectionManager.selectionItems.size, uiState.videos.result.orEmpty().size)
+                } else {
+                    stringResource(R.string.trash)
+                },
+                navigationIcon = {
+                    FilledTonalIconButton(
+                        onClick = {
+                            if (selectionManager.isInSelectionMode) selectionManager.exitSelectionMode() else onNavigateUp()
+                        },
+                        modifier = Modifier.tvFocusRing(),
+                    ) {
+                        Icon(
+                            imageVector = if (selectionManager.isInSelectionMode) NextIcons.Close else NextIcons.ArrowBack,
+                            contentDescription = stringResource(R.string.navigate_up),
+                        )
+                    }
+                },
+                actions = {
+                    if (selectionManager.isInSelectionMode && selectionManager.selectionItems.isNotEmpty()) {
+                        TextButton(
+                            onClick = {
+                                onRestore(selectionManager.selectionItems)
+                                selectionManager.exitSelectionMode()
+                            },
+                            modifier = Modifier.tvFocusRing(),
+                        ) { Text(stringResource(R.string.restore)) }
+                        TextButton(
+                            onClick = { showDeleteConfirmation = true },
+                            modifier = Modifier.tvFocusRing(),
+                        ) { Text(stringResource(R.string.delete)) }
+                    }
+                },
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.surfaceContainer,
+    ) { scaffoldPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(scaffoldPadding.copy(bottom = 0.dp))
+                .clip(RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp))
+                .background(MaterialTheme.colorScheme.background),
+        ) {
+            when (val videos = uiState.videos) {
+                DataState.Loading -> CenterCircularProgressBar()
+                is DataState.Error -> Text(
+                    text = videos.value.message.orEmpty(),
+                    modifier = Modifier.padding(16.dp),
+                    color = MaterialTheme.colorScheme.error,
+                )
+                is DataState.Success -> LazyColumn(
+                    contentPadding = PaddingValues(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    itemsIndexed(videos.value, key = { _, video -> video.uriString }) { index, video ->
+                        VideoListItem(
+                            video = video,
+                            isRecentlyPlayedVideo = false,
+                            preferences = uiState.preferences,
+                            selected = selectionManager.isVideoSelected(video),
+                            isFirstItem = index == 0,
+                            isLastItem = index == videos.value.lastIndex,
+                            onClick = {
+                                if (selectionManager.isInSelectionMode) {
+                                    selectionManager.toggleVideoSelection(video)
+                                } else {
+                                    onPlayVideo(video.uriString)
+                                }
+                            },
+                            onLongClick = { selectionManager.toggleVideoSelection(video) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showDeleteConfirmation) {
+        NextDialog(
+            onDismissRequest = { showDeleteConfirmation = false },
+            title = { Text(stringResource(R.string.delete_permanently)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onDelete(selectionManager.selectionItems)
+                        selectionManager.exitSelectionMode()
+                        showDeleteConfirmation = false
+                    },
+                ) { Text(stringResource(R.string.delete)) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirmation = false }) { Text(stringResource(R.string.cancel)) }
+            },
+            content = { Text(stringResource(R.string.delete_items_info)) },
+        )
+    }
+}

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/trash/TrashViewModel.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/feature/more/screens/trash/TrashViewModel.kt
@@ -1,0 +1,53 @@
+package dev.anilbeesetti.nextplayer.feature.more.screens.trash
+
+import android.net.Uri
+import androidx.core.net.toUri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dev.anilbeesetti.nextplayer.core.data.repository.MediaRepository
+import dev.anilbeesetti.nextplayer.core.data.repository.PreferencesRepository
+import dev.anilbeesetti.nextplayer.core.media.services.MediaOperationsService
+import dev.anilbeesetti.nextplayer.core.model.ApplicationPreferences
+import dev.anilbeesetti.nextplayer.core.model.Video
+import dev.anilbeesetti.nextplayer.core.ui.base.DataState
+import dev.anilbeesetti.nextplayer.feature.videopicker.state.SelectionItem
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class TrashViewModel @Inject constructor(
+    private val mediaOperationsService: MediaOperationsService,
+    mediaRepository: MediaRepository,
+    preferencesRepository: PreferencesRepository,
+) : ViewModel() {
+    val uiState: StateFlow<TrashUiState> = combine(
+        mediaRepository.observeTrashVideos()
+            .map<List<Video>, DataState<List<Video>>> { DataState.Success(it) }
+            .catch { emit(DataState.Error(it)) },
+        preferencesRepository.applicationPreferences,
+    ) { videos, preferences ->
+        TrashUiState(videos = videos, preferences = preferences)
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TrashUiState())
+
+    fun restore(selectionItems: Set<SelectionItem>) {
+        viewModelScope.launch { mediaOperationsService.restoreMedia(selectionItems.toUris()) }
+    }
+
+    fun deletePermanently(selectionItems: Set<SelectionItem>) {
+        viewModelScope.launch { mediaOperationsService.deleteMedia(selectionItems.toUris(), permanently = true) }
+    }
+
+    private fun Set<SelectionItem>.toUris(): List<Uri> = filterIsInstance<SelectionItem.Video>().map { it.uriString.toUri() }
+}
+
+data class TrashUiState(
+    val videos: DataState<List<Video>> = DataState.Loading,
+    val preferences: ApplicationPreferences = ApplicationPreferences(),
+)

--- a/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/MoreNavGraph.kt
+++ b/app/src/main/java/dev/anilbeesetti/nextplayer/navigation/MoreNavGraph.kt
@@ -8,6 +8,8 @@ import androidx.navigation3.runtime.NavKey
 import dev.anilbeesetti.nextplayer.feature.more.navigation.historyEntry
 import dev.anilbeesetti.nextplayer.feature.more.navigation.moreEntry
 import dev.anilbeesetti.nextplayer.feature.more.navigation.navigateToHistory
+import dev.anilbeesetti.nextplayer.feature.more.navigation.navigateToTrash
+import dev.anilbeesetti.nextplayer.feature.more.navigation.trashEntry
 import dev.anilbeesetti.nextplayer.feature.videopicker.navigation.navigateToVault
 import dev.anilbeesetti.nextplayer.feature.videopicker.navigation.vaultEntry
 import dev.anilbeesetti.nextplayer.settings.navigation.navigateToSettings
@@ -20,10 +22,16 @@ fun EntryProviderScope<NavKey>.moreNavGraph(
         onHistoryClick = backStack::navigateToHistory,
         onPlayVideo = { context.startPlayback(it.toUri()) },
         onSettingsClick = backStack::navigateToSettings,
+        onTrashClick = backStack::navigateToTrash,
         onVaultClick = backStack::navigateToVault,
     )
 
     historyEntry(
+        onNavigateUp = { backStack.removeLastIfNotRoot() },
+        onPlayVideo = { context.startPlayback(it.toUri()) },
+    )
+
+    trashEntry(
         onNavigateUp = { backStack.removeLastIfNotRoot() },
         onPlayVideo = { context.startPlayback(it.toUri()) },
     )

--- a/core/data/src/androidTest/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepositoryTest.kt
+++ b/core/data/src/androidTest/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalVaultRepositoryTest.kt
@@ -419,7 +419,9 @@ private class MovingMediaOperationsService(
 
     override fun initialize(activity: ComponentActivity) = Unit
 
-    override suspend fun deleteMedia(uris: List<Uri>): Boolean = true
+    override suspend fun deleteMedia(uris: List<Uri>, permanently: Boolean): Boolean = true
+
+    override suspend fun restoreMedia(uris: List<Uri>): Boolean = true
 
     override suspend fun renameMedia(uri: Uri, to: String): Boolean = false
 
@@ -454,7 +456,9 @@ private class PausedMovingMediaOperationsService : MediaOperationsService {
 
     override fun initialize(activity: ComponentActivity) = Unit
 
-    override suspend fun deleteMedia(uris: List<Uri>): Boolean = true
+    override suspend fun deleteMedia(uris: List<Uri>, permanently: Boolean): Boolean = true
+
+    override suspend fun restoreMedia(uris: List<Uri>): Boolean = true
 
     override suspend fun renameMedia(uri: Uri, to: String): Boolean = false
 

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalMediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalMediaRepository.kt
@@ -78,6 +78,10 @@ class LocalMediaRepository @Inject constructor(
         }
     }
 
+    override fun observeTrashVideos(): Flow<List<Video>> {
+        return mediaService.observeTrashVideos().map { videos -> videos.map { it.toVideo() } }
+    }
+
     override suspend fun getVideoByUri(uri: String): Video? = coroutineScope {
         val mediaVideoDeferred = async { mediaService.findVideo(uri.toUri()) }
         val mediaStateDeferred = async { mediumStateDao.get(uri) }

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/MediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/MediaRepository.kt
@@ -32,6 +32,7 @@ interface MediaRepository {
     fun observeVideos(folderPath: String? = null): Flow<List<Video>>
 
     fun observePlaybackHistory(): Flow<List<Video>>
+    fun observeTrashVideos(): Flow<List<Video>>
 
     /**
      * Fetches all unique folders containing videos under the given path (one-shot).

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/fake/FakeMediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/fake/FakeMediaRepository.kt
@@ -40,6 +40,10 @@ class FakeMediaRepository : MediaRepository {
         return updates.map { videos.filter { it.lastPlayedAt != null }.sortedByDescending { it.lastPlayedAt?.time } }
     }
 
+    override fun observeTrashVideos(): Flow<List<Video>> {
+        return updates.map { emptyList() }
+    }
+
     override suspend fun getVideoByUri(uri: String): Video? {
         return videos.find { it.uriString == uri }
     }

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsService.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/LocalMediaOperationsService.kt
@@ -66,12 +66,16 @@ class LocalMediaOperationsService @Inject constructor(
         }
     }
 
-    override suspend fun deleteMedia(uris: List<Uri>): Boolean = withContext(Dispatchers.IO) {
+    override suspend fun deleteMedia(uris: List<Uri>, permanently: Boolean): Boolean = withContext(Dispatchers.IO) {
         return@withContext if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            deleteMediaR(uris)
+            if (permanently) deleteMediaR(uris) else trashMediaR(uris)
         } else {
             deleteMediaBelowR(uris)
         }
+    }
+
+    override suspend fun restoreMedia(uris: List<Uri>): Boolean = withContext(Dispatchers.IO) {
+        return@withContext Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && trashMediaR(uris, trashed = false)
     }
 
     override suspend fun renameMedia(uri: Uri, to: String): Boolean = withContext(Dispatchers.IO) {
@@ -389,6 +393,22 @@ class LocalMediaOperationsService @Inject constructor(
         itemExists = ::mediaExists,
         request = ::requestDeleteR,
     )
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private suspend fun trashMediaR(uris: List<Uri>, trashed: Boolean = true): Boolean = runMediaRequests(
+        items = uris,
+        itemExists = ::mediaExists,
+        request = { requestTrashR(it, trashed) },
+    )
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private suspend fun requestTrashR(uris: List<Uri>, trashed: Boolean): Boolean = suspendCancellableCoroutine { continuation ->
+        resultOkCallback = { continuation.resume(true) }
+        resultCancelledCallback = { continuation.resume(false) }
+        MediaStore.createTrashRequest(contentResolver, uris, trashed).also { intent ->
+            mediaRequestLauncher?.launch(IntentSenderRequest.Builder(intent).build())
+        }
+    }
 
     @RequiresApi(Build.VERSION_CODES.R)
     private suspend fun requestDeleteR(uris: List<Uri>): Boolean = suspendCancellableCoroutine { continuation ->

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaOperationsService.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaOperationsService.kt
@@ -9,7 +9,8 @@ import kotlinx.coroutines.flow.Flow
 
 interface MediaOperationsService {
     fun initialize(activity: ComponentActivity)
-    suspend fun deleteMedia(uris: List<Uri>): Boolean
+    suspend fun deleteMedia(uris: List<Uri>, permanently: Boolean = false): Boolean
+    suspend fun restoreMedia(uris: List<Uri>): Boolean
     suspend fun renameMedia(uri: Uri, to: String): Boolean
     suspend fun shareMedia(uris: List<Uri>)
     suspend fun moveMedia(targets: Map<Uri, File>): Map<Uri, File?>
@@ -23,6 +24,11 @@ interface MediaOperationsService {
     companion object {
         @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.R)
         fun willSystemAsksForDeleteConfirmation(): Boolean {
+            return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+        }
+
+        @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.R)
+        fun supportsTrash(): Boolean {
             return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
         }
     }

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaService.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaService.kt
@@ -31,6 +31,8 @@ interface MediaService {
      */
     fun observeVideos(folderPath: String? = null): Flow<List<MediaVideo>>
 
+    fun observeTrashVideos(): Flow<List<MediaVideo>>
+
     /**
      * Fetches all unique folders containing videos under the given path (one-shot).
      *

--- a/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaStoreMediaService.kt
+++ b/core/media/src/main/java/dev/anilbeesetti/nextplayer/core/media/services/MediaStoreMediaService.kt
@@ -3,9 +3,12 @@ package dev.anilbeesetti.nextplayer.core.media.services
 import android.content.ContentUris
 import android.content.Context
 import android.database.ContentObserver
+import android.os.Build
+import android.os.Bundle
 import android.database.Cursor
 import android.net.Uri
 import android.provider.MediaStore
+import androidx.annotation.RequiresApi
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.anilbeesetti.nextplayer.core.common.di.ApplicationScope
 import dev.anilbeesetti.nextplayer.core.common.extensions.VIDEO_COLLECTION_URI
@@ -93,6 +96,13 @@ class MediaStoreMediaService @Inject constructor(
             .distinctUntilChanged()
     }
 
+    override fun observeTrashVideos(): Flow<List<MediaVideo>> {
+        return mediaChanges
+            .map { if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) queryTrashVideos() else emptyList() }
+            .flowOn(Dispatchers.IO)
+            .distinctUntilChanged()
+    }
+
     override suspend fun fetchFolders(folderPath: String?): List<MediaFolder> = withContext(Dispatchers.IO) {
         val videos = fetchVideos(folderPath)
 
@@ -167,27 +177,43 @@ class MediaStoreMediaService @Inject constructor(
      */
     private fun File.walkUp() = generateSequence(parentFile) { it.parentFile }
 
-    private fun queryVideos(folderPath: String?): List<MediaVideo> {
-        val mediaVideos = mutableListOf<MediaVideo>()
+    @RequiresApi(Build.VERSION_CODES.R)
+    private fun queryTrashVideos(): List<MediaVideo> {
+        val queryArgs = Bundle().apply {
+            putInt(MediaStore.QUERY_ARG_MATCH_TRASHED, MediaStore.MATCH_ONLY)
+            putStringArray(
+                android.content.ContentResolver.QUERY_ARG_SORT_COLUMNS,
+                arrayOf(MediaStore.Video.Media.DATE_MODIFIED),
+            )
+            putInt(android.content.ContentResolver.QUERY_ARG_SORT_DIRECTION, android.content.ContentResolver.QUERY_SORT_DIRECTION_DESCENDING)
+        }
+        return queryVideoCursor {
+            context.contentResolver.query(VIDEO_COLLECTION_URI, VIDEO_PROJECTION, queryArgs, null)
+        }
+    }
 
+    private fun queryVideos(folderPath: String?): List<MediaVideo> {
         // A null folderPath scans every storage volume (e.g. SD cards / USB OTG). For a specific
         // folder, match it and its descendants, escaping LIKE metacharacters ('%', '_') in the path.
         val selection = if (folderPath == null) null else "${MediaStore.Video.Media.DATA} LIKE ? ESCAPE '\\'"
         val selectionArgs = if (folderPath == null) null else arrayOf("${folderPath.escapeLike()}/%")
         val sortOrder = "${MediaStore.Video.Media.DISPLAY_NAME} ASC"
-
-        val cursor = checkNotNull(
+        return queryVideoCursor {
             context.contentResolver.query(
                 VIDEO_COLLECTION_URI,
                 VIDEO_PROJECTION,
                 selection,
                 selectionArgs,
                 sortOrder,
-            ),
-        ) {
+            )
+        }
+    }
+
+    private fun queryVideoCursor(query: () -> Cursor?): List<MediaVideo> {
+        val mediaVideos = mutableListOf<MediaVideo>()
+        val cursor = checkNotNull(query()) {
             "MediaStore returned no cursor for the video query"
         }
-
         cursor.use {
             while (cursor.moveToNext()) {
                 val video = cursor.toMediaVideo() ?: continue

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -156,6 +156,11 @@
     <string name="seconds">%1$s seconds</string>
     <string name="share">Share</string>
     <string name="delete">Delete</string>
+    <string name="delete_permanently">Delete permanently</string>
+    <string name="restore">Restore</string>
+    <string name="trash">Trash</string>
+    <string name="move_to_trash">Move to trash</string>
+    <string name="move_to_trash_info">Selected items will be moved to trash.</string>
     <string name="delete_file">The following file will be deleted permanently</string>
     <string name="subtitle_text_encoding">Subtitle text encoding</string>
     <string name="fast_playback_speed">%.1fx speed</string>

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerScreen.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.FloatingActionButton
@@ -366,12 +367,7 @@ internal fun MediaPickerScreen(
                     selectionManager.exitSelectionMode()
                 },
                 onDeleteAction = {
-                    if (MediaOperationsService.willSystemAsksForDeleteConfirmation()) {
-                        onAction(MediaPickerAction.DeleteSelectedItems(selectionManager.selectionItems))
-                        selectionManager.exitSelectionMode()
-                    } else {
-                        showDeleteVideosConfirmation = true
-                    }
+                    showDeleteVideosConfirmation = true
                 },
             )
         },
@@ -491,8 +487,9 @@ internal fun MediaPickerScreen(
     if (showDeleteVideosConfirmation) {
         DeleteConfirmationDialog(
             selectionItems = selectionManager.selectionItems,
-            onConfirm = {
-                onAction(MediaPickerAction.DeleteSelectedItems(selectionManager.selectionItems))
+            trashSupported = MediaOperationsService.supportsTrash(),
+            onConfirm = { permanently ->
+                onAction(MediaPickerAction.DeleteSelectedItems(selectionManager.selectionItems, permanently = permanently))
                 selectionManager.exitSelectionMode()
                 showDeleteVideosConfirmation = false
             },
@@ -637,11 +634,13 @@ private fun ProgressSection(
 private fun DeleteConfirmationDialog(
     modifier: Modifier = Modifier,
     selectionItems: Set<SelectionItem>,
-    onConfirm: () -> Unit,
+    trashSupported: Boolean,
+    onConfirm: (Boolean) -> Unit,
     onCancel: () -> Unit,
 ) {
     val selectedVideos = selectionItems.filterIsInstance<SelectionItem.Video>()
     val selectedFolders = selectionItems.filterIsInstance<SelectionItem.Folder>()
+    var permanently by rememberSaveable { mutableStateOf(false) }
 
     NextDialog(
         onDismissRequest = onCancel,
@@ -665,23 +664,36 @@ private fun DeleteConfirmationDialog(
         },
         confirmButton = {
             TextButton(
-                onClick = onConfirm,
+                onClick = { onConfirm(permanently || !trashSupported) },
                 modifier = modifier,
             ) {
-                Text(text = stringResource(R.string.delete))
+                Text(text = stringResource(if (permanently || !trashSupported) R.string.delete else R.string.move_to_trash))
             }
         },
         dismissButton = { CancelButton(onClick = onCancel) },
         modifier = modifier,
         content = {
             Text(
-                text = if ((selectedFolders.size + selectedVideos.size) == 1) {
-                    stringResource(R.string.delete_item_info)
+                text = if (permanently || !trashSupported) {
+                    if ((selectedFolders.size + selectedVideos.size) == 1) {
+                        stringResource(R.string.delete_item_info)
+                    } else {
+                        stringResource(R.string.delete_items_info)
+                    }
                 } else {
-                    stringResource(R.string.delete_items_info)
+                    stringResource(R.string.move_to_trash_info)
                 },
                 style = MaterialTheme.typography.titleSmall,
             )
+            if (trashSupported) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Checkbox(
+                        checked = permanently,
+                        onCheckedChange = { permanently = it },
+                    )
+                    Text(text = stringResource(R.string.delete_permanently))
+                }
+            }
         },
     )
 }

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerViewModel.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerViewModel.kt
@@ -125,7 +125,7 @@ class MediaPickerViewModel @AssistedInject constructor(
             is MediaPickerAction.UpdateMenu -> updateMenu(action.preferences)
             is MediaPickerAction.OnPermissionAccepted -> startMediaCollection()
             is MediaPickerAction.PlaySelectedItems -> playSelectedItems(action.selectionItems)
-            is MediaPickerAction.DeleteSelectedItems -> deleteSelectedItems(action.selectionItems)
+            is MediaPickerAction.DeleteSelectedItems -> deleteSelectedItems(action.selectionItems, action.permanently)
             is MediaPickerAction.ShareSelectedItems -> shareSelectedItems(action.selectionItems)
             is MediaPickerAction.ShowMediaInfo -> showMediaInfo(action.video)
             MediaPickerAction.DismissMediaInfo -> uiStateInternal.update { it.copy(mediaInfo = null) }
@@ -317,10 +317,10 @@ class MediaPickerViewModel @AssistedInject constructor(
         }
     }
 
-    private fun deleteSelectedItems(selectedItems: Set<SelectionItem>) {
+    private fun deleteSelectedItems(selectedItems: Set<SelectionItem>, permanently: Boolean) {
         viewModelScope.launch {
             val videoUris = selectedItems.toVideoUris()
-            mediaOperationsService.deleteMedia(videoUris)
+            mediaOperationsService.deleteMedia(videoUris, permanently = permanently)
         }
     }
 
@@ -559,7 +559,7 @@ sealed interface MediaPickerAction {
     data class UpdateMenu(val preferences: ApplicationPreferences) : MediaPickerAction
     data object OnPermissionAccepted : MediaPickerAction
     data class PlaySelectedItems(val selectionItems: Set<SelectionItem>) : MediaPickerAction
-    data class DeleteSelectedItems(val selectionItems: Set<SelectionItem>) : MediaPickerAction
+    data class DeleteSelectedItems(val selectionItems: Set<SelectionItem>, val permanently: Boolean = false) : MediaPickerAction
     data class ShareSelectedItems(val selectionItems: Set<SelectionItem>) : MediaPickerAction
     data class CopySelectedItems(val selectionItems: Set<SelectionItem>) : MediaPickerAction
     data class MoveSelectedItems(val selectionItems: Set<SelectionItem>) : MediaPickerAction


### PR DESCRIPTION
Add a Trash destination under More and let users restore trashed videos or delete them permanently. On Android 11/API 30 and later, media selection offers moving videos to trash with an optional permanent-delete choice and uses Android's system confirmation requests. Older Android versions retain permanent deletion and do not show the Trash entry.

Observe trashed MediaStore videos separately from the library, reuse the existing batched media-request runner, and update repository interfaces and vault instrumentation test fixtures for trash/restore support.

Validation: `./gradlew assembleDebug test ktlintCheck :core:data:assembleDebugAndroidTest` passes; 171 local tests, zero failures/errors. The final task compiles the affected vault test fixtures.

Split from local `refactor-nav` at `02c0f369`. Review against `codex/refactor-nav-history`; this PR adds trash to the More screen established by the earlier PRs.

Stack / merge order: #1907 → #1908 → #1909 → #1910. Each child targets its preceding PR branch so GitHub shows only that step. Merge in this order; retarget/rebase the next child onto `main` after its parent merges as needed.

Screenshots — media selection confirmation and Trash:

<img src="https://raw.githubusercontent.com/anilbeesetti/nextplayer/75edde6fa7c4ee9ddbd3223ab576bf40f2162121/fastlane/metadata/android/en-US/images/refactor-nav-review/trash-confirmation.png" width="260" /> <img src="https://raw.githubusercontent.com/anilbeesetti/nextplayer/75edde6fa7c4ee9ddbd3223ab576bf40f2162121/fastlane/metadata/android/en-US/images/refactor-nav-review/trash-list.png" width="260" />

Emulator verification: disposable Pixel 6a, Android 17/API 37, arm64/16 KB pages. Selected the generated video, chose Move to trash, approved Android's prompt, and confirmed it disappeared from the library and appeared in Trash. Restored it through Android's prompt and verified the file returned to Movies with `is_trashed=0`. Permanent deletion and the pre-API-30 fallback were not exercised on-device. The screenshot records the current MediaStore-provided trashed filename.
