### PR TITLE
Show placeholder when decoder mode is unavailable

### DIFF
--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/controls/ControlsTopView.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/controls/ControlsTopView.kt
@@ -41,7 +41,7 @@ fun ControlsTopView(
     onBackClick: () -> Unit,
 ) {
     val systemBarsPadding = WindowInsets.systemBars.union(WindowInsets.displayCutout).asPaddingValues()
-    val videoDecoderLabel = stringResource(videoDecoderMode?.labelRes ?: R.string.select_decoders)
+    val videoDecoderLabel = videoDecoderMode?.labelRes?.let { stringResource(it) } ?: "-"
     // Add top spacing only when the system bars don't already provide it (e.g. on TV / landscape).
     val extraTopPadding = if (systemBarsPadding.calculateTopPadding() == 0.dp) 16.dp else 0.dp
     Row(


### PR DESCRIPTION
Show `-` in the player controls when the active decoder mode is unavailable. This preserves the one-line decoder-label change from `refactor-nav` separately from the navigation work.

This PR targets `main` and has no dependency on the navigation stack.

Validation: `./gradlew assembleDebug test ktlintCheck` passes; 170 local tests, zero failures/errors. This is a one-line fallback-text change; the unavailable-decoder state was checked in source, without a dedicated emulator reproduction.
