### PR TITLE
Fix vault setup and missing history metadata

### DIFF
--- a/core/ui/src/main/res/values-ar/strings.xml
+++ b/core/ui/src/main/res/values-ar/strings.xml
@@ -324,9 +324,6 @@
     <string name="enter_vault_pin_description">أدخل رمزك للوصول إلى الفيديوهات المخفية</string>
     <string name="pins_do_not_match">الرمزان غير متطابقين. حاول مرة أخرى</string>
     <string name="incorrect_pin">رمز غير صحيح</string>
-    <string name="how_to_find_hidden_videos_title">\"كيف تجد فيديوهاتك المخفية</string>
-    <string name="how_to_find_hidden_videos_description">الفيديوهات المخفية محفوطة بآمان في الخزنة. لإعادة فتحها، افتح المزيد، ثم اضغط على فتح الخزنة، وأدخل الرمز الشخصي (PIN).</string>
-    <string name="got_it">فهمت</string>
     <string name="open_vault">فتح الخزنة</string>
     <string name="vault_empty_title">لا توجد فيديوهات مخفية</string>
     <string name="vault_empty_description">ستظهر هنا الفيديوهات التي تخفيها. اضغط مطولاً على الفيديو ثم اختر \"أخفِ\" لإضافته إلى الخزنة.</string>

--- a/core/ui/src/main/res/values-cs/strings.xml
+++ b/core/ui/src/main/res/values-cs/strings.xml
@@ -293,9 +293,6 @@
     <string name="confirm_vault_pin">Potvrzení PINu</string>
     <string name="confirm_vault_pin_description">Zadejte váš PIN znovu pro potvrzení</string>
     <string name="enter_vault_pin">Zadejte PIN</string>
-    <string name="how_to_find_hidden_videos_title">Jak najít vaše skryté videa</string>
-    <string name="how_to_find_hidden_videos_description">Skryté videa jsou zabezpečeny ve vašem sejfu. Pro jeho otevření, přejděte na kartu Více, klepněte na Otevřít sejf a zadejte váš PIN.</string>
-    <string name="got_it">Rozumím</string>
     <string name="open_vault">Otevřít sejf</string>
     <string name="vault_empty_title">Žádné skryté videa</string>
     <string name="vault_empty_description">Skryté videa se budou zobrazovat zde. Na video udělejte dlouhé klepnutí a klepněte na Skyýt pro přidání do sejfu.</string>

--- a/core/ui/src/main/res/values-el/strings.xml
+++ b/core/ui/src/main/res/values-el/strings.xml
@@ -320,13 +320,10 @@
     <string name="enter_vault_pin_description">Εισάγετε το PIN σας για να αποκτήσετε πρόσβαση στα κρυφά βίντεο</string>
     <string name="pins_do_not_match">Τα PIN δεν ταιριάζουν. Δοκιμάστε ξανά</string>
     <string name="incorrect_pin">Λανθασμένο PIN</string>
-    <string name="how_to_find_hidden_videos_title">Πώς να βρείτε τα κρυφά σας βίντεο</string>
-    <string name="how_to_find_hidden_videos_description">Τα κρυμμένα βίντεο φυλάσσονται με ασφάλεια στην κρύπτη σας. Για να την ανοίξετε ξανά, πατήστε Περισσότερα, Άνοιγμα κρύπτης και εισάγετε το PIN σας.</string>
     <string name="open_vault">Άνοιγμα κρύπτης</string>
     <string name="vault_empty_title">Κανένα κρυφό βίντεο</string>
     <string name="vault_empty_description">Τα βίντεο που αποκρύπτετε θα εμφανίζονται εδώ. Πατήστε παρατεταμένα ένα βίντεο και πατήστε Απόκρυψη για να το προσθέσετε στο αρχείο καταγραφής.</string>
     <string name="folder_duration">Διάρκεια φακέλου</string>
-    <string name="got_it">Κατάλαβα</string>
     <string name="unhide_one_video_confirmation">Επανεμφάνιση αυτού του βίντεο; Θα μετακινηθεί πίσω στην αρχική του θέση.</string>
     <string name="unhide_videos_confirmation">Επανεμφάνιση %1$d βίντεο; Θα μετακινηθούν πίσω στην αρχική τους θέση.</string>
     <string name="delete_one_video_from_vault">Μόνιμη διαγραφή του βίντεο;</string>

--- a/core/ui/src/main/res/values-es/strings.xml
+++ b/core/ui/src/main/res/values-es/strings.xml
@@ -322,9 +322,6 @@
     <string name="enter_vault_pin_description">Ingrese su PIN para acceder a vídeos ocultos</string>
     <string name="pins_do_not_match">Los PIN no coinciden. Inténtalo de nuevo</string>
     <string name="incorrect_pin">PIN incorrecto</string>
-    <string name="how_to_find_hidden_videos_title">Cómo encontrar tus vídeos ocultos</string>
-    <string name="how_to_find_hidden_videos_description">Los vídeos ocultos se mantienen a salvo en tu Bóveda. Para abrirla de nuevo, ve a Más, toca en Abrir bóveda e introduce tu PIN.</string>
-    <string name="got_it">Entendido</string>
     <string name="open_vault">Abrir bóveda</string>
     <string name="vault_empty_title">Sin vídeos ocultos</string>
     <string name="vault_empty_description">Los vídeos que ocultes aparecerán aquí. Mantén presionado un vídeo y toca Ocultar para agregarlo a la bóveda.</string>

--- a/core/ui/src/main/res/values-et/strings.xml
+++ b/core/ui/src/main/res/values-et/strings.xml
@@ -317,8 +317,6 @@
     <string name="enter_vault_pin_description">Ligipääsuks oma peidetud videotele sisesta PIN-kood</string>
     <string name="pins_do_not_match">PIN-koodid ei klapi. Proovi uuesti</string>
     <string name="incorrect_pin">Vigane PIN-kood</string>
-    <string name="how_to_find_hidden_videos_title">Kuidas saad leida oma peidetud videoid</string>
-    <string name="got_it">Selge</string>
     <string name="open_vault">Ava turvakaust</string>
     <string name="vault_empty_title">Peidetud videoid pole</string>
     <string name="sort_by">Järjestus</string>
@@ -357,7 +355,6 @@
         <item quantity="one">Video taastamine tema algkausta ei õnnestunud, selle asemel tõstsin kausta „Movies/“</item>
         <item quantity="other">%1$d video taastamine nende algkausta ei õnnestunud, selle asemel tõstsin kausta „Movies/“</item>
     </plurals>
-    <string name="how_to_find_hidden_videos_description">Peidetud videoid hoitakse turvaliselt sinu turvakaustas. Uuesti avamiseks vajuta NextPlayeri pealkirja ekraani ülaosas ja hoia all ning siis sisesta oma turvakausta PIN-kood.</string>
     <string name="vault_empty_description">Sinu peidetavad videod saavad olema nähtavad siin. Turvakausta lisamiseks vajuta videot pikalt ja vali „Peida“.</string>
     <string name="unhide_one_video_confirmation">Kas lõpetad selle video peitmine? Ta tõstetakse tagasi oma algsesse kausta.</string>
     <string name="unhide_videos_confirmation">Kas lõpetad %1$d video peitmine? Nad tõstetakse tagasi oma algse(te)sse kausta(desse).</string>

--- a/core/ui/src/main/res/values-fa/strings.xml
+++ b/core/ui/src/main/res/values-fa/strings.xml
@@ -321,9 +321,6 @@
     <string name="enter_vault_pin_description">رمز کوتاه را برای دسترسی به ویدیوهای پنهان وارد کنید</string>
     <string name="pins_do_not_match">رمزهای کوتاه مطابقت ندارند. دوباره تلاش کنید</string>
     <string name="incorrect_pin">رمز کوتاه نادرست</string>
-    <string name="how_to_find_hidden_videos_title">چگونه ویدیوهای پنهان خود را پیدا کنید</string>
-    <string name="how_to_find_hidden_videos_description">ویدیوهای پنهان در گاوصندوق شما امن نگه داشته می‌شوند. برای باز کردن دوباره، عنوان «NextPlayer» در بالای صفحه خانگی را نگه دارید و رمز کوتاه را وارد کنید.</string>
-    <string name="got_it">فهمیدم</string>
     <string name="open_vault">باز کردن گاوصندوق</string>
     <string name="vault_empty_title">هیچ ویدیوی پنهانی نیست</string>
     <string name="vault_empty_description">ویدیوهایی که پنهان می‌کنید اینجا نمایش داده می‌شوند. روی ویدیو نگه دارید و روی پنهان کردن بزنید تا به گاوصندوق افزوده شود.</string>

--- a/core/ui/src/main/res/values-fr/strings.xml
+++ b/core/ui/src/main/res/values-fr/strings.xml
@@ -338,9 +338,6 @@
     <string name="enter_vault_pin_description">Entrez votre code PIN pour accéder aux éléments masqués</string>
     <string name="pins_do_not_match">Les codes PIN sont différents. Réessayez</string>
     <string name="incorrect_pin">Code PIN incorrect</string>
-    <string name="how_to_find_hidden_videos_title">Comment trouver les éléments masqués</string>
-    <string name="how_to_find_hidden_videos_description">Les vidéos ajoutées aux éléments masqués sont sécurisées. Pour y accéder, appuyez sur Plus, puis Accéder aux éléments sécurisés, et entrez votre code PIN.</string>
-    <string name="got_it">Compris</string>
     <string name="open_vault">Accéder aux éléments sécurisés</string>
     <string name="open_vault_description">Accéder aux éléments sécurisés</string>
     <string name="unlock_with_biometrics">Déverrouillage biométrique</string>

--- a/core/ui/src/main/res/values-hi/strings.xml
+++ b/core/ui/src/main/res/values-hi/strings.xml
@@ -321,9 +321,6 @@
     <string name="enter_vault_pin_description">छिपे हुए वीडियोज़ तक पहुंच करने के लिए अपना पिन डालें</string>
     <string name="pins_do_not_match">पिन मैच नहीं कर रहे हैं। फिर से कोशिश करें</string>
     <string name="incorrect_pin">गलत पिन</string>
-    <string name="how_to_find_hidden_videos_title">अपने छिपे हुए वीडियो कैसे ढूंढने हैं</string>
-    <string name="how_to_find_hidden_videos_description">छिपे हुए वीडियो आपके वॉल्ट में सुरक्षित रहते हैं। इसे फिर से खोलने के लिए, होम स्क्रीन के ऊपर \"NextPlayer\" टाइटल को दबाकर रखें और अपना पिन डालें।</string>
-    <string name="got_it">समझ गया</string>
     <string name="open_vault">वॉल्ट खोलें</string>
     <string name="vault_empty_title">कोई छिपा हुआ वीडियो नहीं</string>
     <string name="vault_empty_description">आपके छिपाए हुए वीडियो यहां दिखेंगे। किसी वीडियो को देर तक दबाकर रखें और उसे वॉल्ट में जोड़ने के लिए छिपाएं पर टैप करें।</string>

--- a/core/ui/src/main/res/values-in/strings.xml
+++ b/core/ui/src/main/res/values-in/strings.xml
@@ -344,9 +344,6 @@
     <string name="enter_vault_pin_description">Masukkan PIN Anda untuk mengakses video tersembunyi</string>
     <string name="pins_do_not_match">PIN tidak cocok. Coba lagi</string>
     <string name="incorrect_pin">PIN salah</string>
-    <string name="how_to_find_hidden_videos_title">Cara menemukan video tersembunyi Anda</string>
-    <string name="how_to_find_hidden_videos_description">Video tersembunyi Anda disimpan dengan aman di Brankas. Untuk membukanya kembali, tekan dan tahan judul \"NextPlayer\" di bagian atas layar beranda, lalu masukkan PIN Anda.</string>
-    <string name="got_it">Mengerti</string>
     <string name="open_vault">Buka brankas</string>
     <string name="vault_empty_title">Tidak ada video tersembunyi</string>
     <string name="vault_empty_description">Video yang Anda sembunyikan akan muncul di sini. Tekan lama video, lalu ketuk Sembunyikan untuk menambahkannya ke brankas.</string>

--- a/core/ui/src/main/res/values-ja/strings.xml
+++ b/core/ui/src/main/res/values-ja/strings.xml
@@ -348,10 +348,7 @@
     <string name="enter_vault_pin_description">非表示にした動画にアクセスするには PIN を入力してください</string>
     <string name="pins_do_not_match">PIN が一致しません。もう一度お試しください</string>
     <string name="incorrect_pin">PIN が間違っています</string>
-    <string name="how_to_find_hidden_videos_title">非表示にした動画を見つける方法</string>
-    <string name="how_to_find_hidden_videos_description">非表示にした動画は保管庫に安全に保管されています。再度開くには、ホーム画面上部の「NextPlayer」タイトルを長押しし、PIN を入力してください。</string>
     <string name="reset_controller_timeout">コントローラーが非表示になるまでの時間をリセット</string>
-    <string name="got_it">わかりました</string>
     <string name="open_vault">保管庫を開く</string>
     <string name="vault_empty_title">非表示にした動画はありません</string>
     <string name="vault_empty_description">非表示にした動画はここに表示されます。動画を長押しして「非表示」をタップすると、動画を保管庫に追加できます。</string>

--- a/core/ui/src/main/res/values-pa/strings.xml
+++ b/core/ui/src/main/res/values-pa/strings.xml
@@ -321,9 +321,6 @@
     <string name="enter_vault_pin_description">ਲੁਕੇ ਹੋਏ ਵੀਡੀਓ ਤੱਕ ਪਹੁੰਚ ਕਰਨ ਲਈ ਆਪਣਾ ਪਿੰਨ ਦਰਜ ਕਰੋ</string>
     <string name="pins_do_not_match">ਪਿੰਨ ਮੇਲ ਨਹੀਂ ਖਾਂਦੇ। ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ</string>
     <string name="incorrect_pin">ਗਲਤ ਪਿੰਨ</string>
-    <string name="how_to_find_hidden_videos_title">ਆਪਣੇ ਲੁਕਵੇਂ ਵੀਡੀਓ ਕਿਵੇਂ ਲੱਭਣੇ ਹਨ</string>
-    <string name="how_to_find_hidden_videos_description">ਲੁਕੇ ਹੋਏ ਵੀਡੀਓ ਤੁਹਾਡੇ ਵਾਲਟ ਵਿੱਚ ਸੁਰੱਖਿਅਤ ਰੱਖੇ ਜਾਂਦੇ ਹਨ। ਇਸਨੂੰ ਦੁਬਾਰਾ ਖੋਲ੍ਹਣ ਲਈ, ਹੋਮ ਸਕ੍ਰੀਨ ਦੇ ਸਿਖਰ \'ਤੇ \"NextPlayer\" ਸਿਰਲੇਖ ਨੂੰ ਦਬਾ ਕੇ ਰੱਖੋ ਅਤੇ ਆਪਣਾ PIN ਦਰਜ ਕਰੋ।</string>
-    <string name="got_it">ਸਮਝ ਗਿਆ</string>
     <string name="open_vault">ਖੁੱਲ੍ਹਾ ਵਾਲਟ</string>
     <string name="vault_empty_title">ਕੋਈ ਲੁਕਵੇਂ ਵੀਡੀਓ ਨਹੀਂ</string>
     <string name="vault_empty_description">ਤੁਹਾਡੇ ਵੱਲੋਂ ਲੁਕਾਏ ਗਏ ਵੀਡੀਓ ਇੱਥੇ ਦਿਖਾਈ ਦੇਣਗੇ। ਕਿਸੇ ਵੀਡੀਓ ਨੂੰ ਦੇਰ ਤੱਕ ਦਬਾਓ ਅਤੇ ਇਸਨੂੰ ਵਾਲਟ ਵਿੱਚ ਸ਼ਾਮਿਲ ਕਰਨ ਲਈ ਲੁਕਾਓ \'ਤੇ ਟੈਪ ਕਰੋ।</string>

--- a/core/ui/src/main/res/values-pl/strings.xml
+++ b/core/ui/src/main/res/values-pl/strings.xml
@@ -322,9 +322,6 @@
     <string name="enter_vault_pin_description">Wprowadź swój kod PIN, aby uzyskać dostęp do ukrytych wideo</string>
     <string name="pins_do_not_match">Kody PIN nie są zgodne. Spróbuj ponownie</string>
     <string name="incorrect_pin">Nieprawidłowy kod PIN</string>
-    <string name="how_to_find_hidden_videos_title">Jak znaleźć swoje ukryte wideo</string>
-    <string name="how_to_find_hidden_videos_description">Ukryte wideo są bezpiecznie przechowywane w twoim sejfie. Aby je ponownie otworzyć, wybierz opcję „Więcej”, dotknij „Otwórz sejf” i wprowadź swój kod PIN.</string>
-    <string name="got_it">Rozumiem</string>
     <string name="open_vault">Otwórz sejf</string>
     <string name="vault_empty_title">Brak ukrytych wideo</string>
     <string name="vault_empty_description">W tym miejscu pojawi się wideo, które ukryjesz. Naciśnij i przytrzymaj wideo, a następnie wybierz opcję „Ukryj”, aby przenieść je do sejfu.</string>

--- a/core/ui/src/main/res/values-ru/strings.xml
+++ b/core/ui/src/main/res/values-ru/strings.xml
@@ -325,9 +325,6 @@
     <string name="enter_vault_pin_description">Введите PIN-код для доступа к скрытым видео</string>
     <string name="pins_do_not_match">PIN-коды не совпадают. Попробуйте ещё раз</string>
     <string name="incorrect_pin">Неверный PIN-код</string>
-    <string name="how_to_find_hidden_videos_title">Как найти скрытые видео</string>
-    <string name="how_to_find_hidden_videos_description">Скрытые видео надёжно защищены в вашем хранилище. Чтобы снова зайти в него, перейдите в раздел «Ещё», нажмите «Открыть хранилище» и введите свой PIN-код.</string>
-    <string name="got_it">Понятно</string>
     <string name="open_vault">Открыть секретную папку</string>
     <string name="vault_empty_title">Скрытых видео нет</string>
     <string name="delete_one_video_from_vault">Удалить это видео навсегда?</string>

--- a/core/ui/src/main/res/values-sq/strings.xml
+++ b/core/ui/src/main/res/values-sq/strings.xml
@@ -321,9 +321,6 @@
     <string name="enter_vault_pin_description">Vendos PIN-in tënd për të hyrë te videot e fshehura</string>
     <string name="pins_do_not_match">PIN-et nuk përputhen. Provo përsëri</string>
     <string name="incorrect_pin">PIN i gabuar</string>
-    <string name="how_to_find_hidden_videos_title">Si t\'i gjesh videot e tua të fshehura</string>
-    <string name="how_to_find_hidden_videos_description">Videot e fshehura mbahen të sigurta në Kasafortën tënde. Për ta hapur përsëri, shtyp dhe mbaj titullin \"NextPlayer\" në krye të ekranit kryesor dhe vendos PIN-in tënd.</string>
-    <string name="got_it">E kuptova</string>
     <string name="open_vault">Hap kasafortën</string>
     <string name="vault_empty_title">Nuk ka video të fshehura</string>
     <string name="vault_empty_description">Videot që fsheh do të shfaqen këtu. Shtyp gjatë një video dhe trokit \'Fshih\' për ta shtuar te kasaforta.</string>

--- a/core/ui/src/main/res/values-tr/strings.xml
+++ b/core/ui/src/main/res/values-tr/strings.xml
@@ -317,8 +317,6 @@
     <string name="enter_vault_pin_description">Gizli videolara erişmek için PIN\'inizi girin</string>
     <string name="pins_do_not_match">PIN\'ler eşleşmiyor. Tekrar deneyin</string>
     <string name="incorrect_pin">Yanlış PIN</string>
-    <string name="how_to_find_hidden_videos_title">Gizli videolarınızı nasıl bulabilirsiniz</string>
-    <string name="how_to_find_hidden_videos_description">Gizli videolarınız Kasanızda güvenli bir şekilde saklanır. Tekrar açmak için ana ekranın üst kısmındaki \"NextPlayer\" başlığına basılı tutun ve PIN\'inizi girin.</string>
     <string name="open_vault">Kasayı aç</string>
     <string name="vault_empty_title">Gizli video yok</string>
     <string name="vault_empty_description">Gizlediğiniz videolar burada görünecektir. Bir videoya uzun süre basılı tutun ve Gizle seçeneğine dokunarak onu kasaya ekleyin.</string>
@@ -362,7 +360,6 @@
         <item quantity="one">Orijinal klasörü geri yüklenemedi — Filmler/ klasörüne taşındı</item>
         <item quantity="other">%1$d videonun orijinal klasörü geri yüklenemedi — Filmler/ klasörüne taşındı</item>
     </plurals>
-    <string name="got_it">Anladım</string>
     <string name="transfer_file_progress">Dosya %1$d / %2$d</string>
     <string name="home">Ana Sayfa</string>
     <string name="network">Ağ</string>

--- a/core/ui/src/main/res/values-uk/strings.xml
+++ b/core/ui/src/main/res/values-uk/strings.xml
@@ -322,9 +322,6 @@
     <string name="enter_vault_pin_description">Введіть PIN-код для перегляду прихованих відео</string>
     <string name="pins_do_not_match">PIN-коди не збігаються. Спробуйте ще раз</string>
     <string name="incorrect_pin">Неправильний PIN-код</string>
-    <string name="how_to_find_hidden_videos_title">Як знайти ваші приховані відео</string>
-    <string name="how_to_find_hidden_videos_description">Приховані відео надійно зберігаються у вашому сховищі. Щоб знову відкрити їх, натисніть і утримуйте заголовок «NextPlayer» у верхній частині головного екрана та введіть PIN-код.</string>
-    <string name="got_it">Зрозуміло</string>
     <string name="open_vault">Відкрити сховище</string>
     <string name="vault_empty_title">Немає прихованих відео</string>
     <string name="vault_empty_description">Відео, які ви приховаєте, з’являтимуться тут. Натисніть і утримуйте відео, а потім виберіть «Приховати», щоби додати його до сховища.</string>

--- a/core/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/core/ui/src/main/res/values-zh-rCN/strings.xml
@@ -320,9 +320,6 @@
     <string name="pins_do_not_match">PIN 码不匹配。请重试。</string>
     <string name="incorrect_pin">PIN 码错误</string>
     <string name="reset_vault_pin_confirmation">重置 PIN 码会永久删除当前在保险箱中的所有视频，因为已无法再将其解锁。继续吗？</string>
-    <string name="how_to_find_hidden_videos_description">隐藏的视频安全地存放在保险箱中。要重新打开保险箱，请打开“更多”，点按“打开保险箱”，并输入 PIN 码。</string>
-    <string name="how_to_find_hidden_videos_title">如何找到隐藏的视频</string>
-    <string name="got_it">知道了</string>
     <string name="open_vault">打开保险箱</string>
     <string name="vault_empty_title">没有隐藏的视频</string>
     <string name="vault_empty_description">隐藏的视频会出现在此。长按视频并点按“隐藏”可将其添加到保险箱。</string>

--- a/core/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/core/ui/src/main/res/values-zh-rTW/strings.xml
@@ -320,9 +320,6 @@
     <string name="enter_vault_pin_description">請輸入密碼以存取您的影片</string>
     <string name="pins_do_not_match">PIN 碼不符，請再試一次</string>
     <string name="incorrect_pin">錯誤的 PIN 碼</string>
-    <string name="how_to_find_hidden_videos_title">如何尋找您隱藏的影片</string>
-    <string name="how_to_find_hidden_videos_description">隱藏的影片皆妥善存放於保險箱。\n如要再次查看，請按下「更多」開啟保險箱並輸入密碼。</string>
-    <string name="got_it">知道了</string>
     <string name="open_vault">開啟保險箱</string>
     <string name="vault_empty_title">沒有隱藏的影片</string>
     <string name="vault_empty_description">您隱藏的影片將會顯示在這裡。\n按住影片並選擇「隱藏」即可加入保險箱。</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -349,9 +349,6 @@
     <string name="enter_vault_pin_description">Enter your PIN to access hidden videos</string>
     <string name="pins_do_not_match">PINs don\'t match. Try again</string>
     <string name="incorrect_pin">Incorrect PIN</string>
-    <string name="how_to_find_hidden_videos_title">How to find your hidden videos</string>
-    <string name="how_to_find_hidden_videos_description">Hidden videos are kept safe in your Vault. To open it again, open More, tap Open vault, and enter your PIN.</string>
-    <string name="got_it">Got it</string>
     <string name="open_vault">Open vault</string>
     <string name="open_vault_description">Access your hidden videos</string>
     <string name="unlock_with_biometrics">Unlock with biometrics</string>

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/VideoItem.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/composables/VideoItem.kt
@@ -100,6 +100,11 @@ fun VideoListItem(
     onClick: () -> Unit = {},
     onLongClick: (() -> Unit)? = null,
 ) {
+    val path = video.path.substringBeforeLast("/")
+    val showPath = preferences.showPathField && path.isNotBlank()
+    val showSize = preferences.showSizeField && video.size > 0 && video.formattedFileSize.isNotBlank()
+    val showResolution = preferences.showResolutionField && video.height > 0
+
     NextSegmentedListItem(
         modifier = modifier,
         selected = selected,
@@ -137,31 +142,37 @@ fun VideoListItem(
                 overflow = TextOverflow.Ellipsis,
             )
         },
-        supportingContent = {
-            Column(
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                if (preferences.showPathField) {
-                    Text(
-                        text = video.path.substringBeforeLast("/"),
-                        maxLines = 2,
-                        style = MaterialTheme.typography.bodySmall,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-                FlowRow(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(5.dp),
-                    verticalArrangement = Arrangement.spacedBy(5.dp),
+        supportingContent = if (showPath || showSize || showResolution) {
+            {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
-                    if (preferences.showSizeField) {
-                        InfoChip(text = video.formattedFileSize)
+                    if (showPath) {
+                        Text(
+                            text = path,
+                            maxLines = 2,
+                            style = MaterialTheme.typography.bodySmall,
+                            overflow = TextOverflow.Ellipsis,
+                        )
                     }
-                    if (preferences.showResolutionField && video.height > 0) {
-                        InfoChip(text = "${video.height}p")
+                    if (showSize || showResolution) {
+                        FlowRow(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(5.dp),
+                            verticalArrangement = Arrangement.spacedBy(5.dp),
+                        ) {
+                            if (showSize) {
+                                InfoChip(text = video.formattedFileSize)
+                            }
+                            if (showResolution) {
+                                InfoChip(text = "${video.height}p")
+                            }
+                        }
                     }
                 }
             }
+        } else {
+            null
         },
     )
 }
@@ -271,7 +282,7 @@ private fun ThumbnailView(
                 modifier = Modifier.fillMaxSize(),
             )
         }
-        if (preferences.showDurationField) {
+        if (preferences.showDurationField && video.duration > 0 && video.formattedDuration.isNotBlank()) {
             InfoChip(
                 text = video.formattedDuration,
                 modifier = Modifier

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerScreen.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerScreen.kt
@@ -738,19 +738,6 @@ private fun HideFlowDialogs(
         }
 
         HideFlowState.BiometricSetup -> VaultBiometricSetupDialog(onComplete = onBiometricSetupComplete)
-
-        HideFlowState.HowToFindInfo -> {
-            NextDialog(
-                onDismissRequest = onDismiss,
-                title = { Text(text = stringResource(R.string.how_to_find_hidden_videos_title)) },
-                content = { Text(text = stringResource(R.string.how_to_find_hidden_videos_description)) },
-                confirmButton = {
-                    TextButton(onClick = onDismiss) {
-                        Text(text = stringResource(R.string.got_it))
-                    }
-                },
-            )
-        }
     }
 }
 

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerViewModel.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/mediapicker/MediaPickerViewModel.kt
@@ -463,7 +463,7 @@ class MediaPickerViewModel @AssistedInject constructor(
         if (stateInternal.value.hideFlow != HideFlowState.BiometricSetup) return
         viewModelScope.launch {
             vaultPinRepository.setBiometricEnabled(enabled)
-            stateInternal.update { it.copy(hideFlow = HideFlowState.HowToFindInfo) }
+            stateInternal.update { it.copy(hideFlow = HideFlowState.Idle) }
         }
     }
 
@@ -542,7 +542,6 @@ sealed interface HideFlowState {
     data class ConfirmHide(val items: List<Video>) : HideFlowState
     data class SetupPin(val items: List<Video>) : HideFlowState
     data object BiometricSetup : HideFlowState
-    data object HowToFindInfo : HideFlowState
 
     data object Processing : HideFlowState
 }

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultScreen.kt
@@ -170,12 +170,6 @@ internal fun VaultScreenContent(
             onComplete = { onAction(VaultAction.CompleteBiometricSetup(it)) },
         )
 
-        VaultStage.HOW_TO_FIND_INFO -> {
-            HowToFindHiddenVideosDialog(
-                onDismiss = { onAction(VaultAction.DismissHowToFindInfo) },
-            )
-        }
-
         VaultStage.UNLOCKED -> VaultGalleryContent(
             state = state,
             onAction = onAction,
@@ -373,22 +367,6 @@ private fun PinEntryHeader(
             )
         }
     }
-}
-
-@Composable
-private fun HowToFindHiddenVideosDialog(
-    onDismiss: () -> Unit,
-) {
-    NextDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(text = stringResource(R.string.how_to_find_hidden_videos_title)) },
-        content = { Text(text = stringResource(R.string.how_to_find_hidden_videos_description)) },
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(text = stringResource(R.string.got_it))
-            }
-        },
-    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)

--- a/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt
+++ b/feature/videopicker/src/main/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultViewModel.kt
@@ -98,7 +98,6 @@ class VaultViewModel @AssistedInject constructor(
             }
             is VaultAction.CompleteBiometricSetup -> completeBiometricSetup(action.enabled)
             is VaultAction.SetBiometricEnabled -> setBiometricEnabled(action.enabled)
-            is VaultAction.DismissHowToFindInfo -> dismissHowToFindInfo()
             is VaultAction.PlayVideo -> playVideo(action.video)
             is VaultAction.PlaySelected -> playSelected(action.selectionItems)
             is VaultAction.UnhideSelected -> unhideVideos(action.selectionItems)
@@ -162,7 +161,8 @@ class VaultViewModel @AssistedInject constructor(
         if (stateInternal.value.stage != VaultStage.BIOMETRIC_SETUP) return
         viewModelScope.launch {
             vaultPinRepository.setBiometricEnabled(enabled)
-            stateInternal.update { it.copy(stage = VaultStage.HOW_TO_FIND_INFO, biometricEnabled = enabled) }
+            stateInternal.update { it.copy(biometricEnabled = enabled) }
+            unlockVault()
         }
     }
 
@@ -172,10 +172,6 @@ class VaultViewModel @AssistedInject constructor(
             vaultPinRepository.setBiometricEnabled(enabled)
             stateInternal.update { it.copy(biometricEnabled = enabled) }
         }
-    }
-
-    private fun dismissHowToFindInfo() {
-        unlockVault()
     }
 
     private fun unlockVault() {
@@ -242,7 +238,6 @@ enum class VaultStage {
     SET_PIN,
     CONFIRM_PIN,
     BIOMETRIC_SETUP,
-    HOW_TO_FIND_INFO,
     UNLOCKED,
 }
 
@@ -270,7 +265,6 @@ sealed interface VaultAction {
     data object BiometricAuthenticated : VaultAction
     data class CompleteBiometricSetup(val enabled: Boolean) : VaultAction
     data class SetBiometricEnabled(val enabled: Boolean) : VaultAction
-    data object DismissHowToFindInfo : VaultAction
     data class PlayVideo(val video: Video) : VaultAction
     data class PlaySelected(val selectionItems: Set<SelectionItem>) : VaultAction
     data class UnhideSelected(val selectionItems: Set<SelectionItem>) : VaultAction

--- a/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultAuthenticationTest.kt
+++ b/feature/videopicker/src/test/java/dev/anilbeesetti/nextplayer/feature/videopicker/screens/vault/VaultAuthenticationTest.kt
@@ -139,7 +139,9 @@ class VaultAuthenticationTest {
 
         assertTrue(biometricEnabled)
         assertTrue(viewModel.state.value.biometricEnabled)
-        assertEquals(VaultStage.HOW_TO_FIND_INFO, viewModel.state.value.stage)
+        assertEquals(VaultStage.UNLOCKED, viewModel.state.value.stage)
+        assertEquals(listOf(Video.sample), viewModel.state.value.hiddenVideos)
+        assertEquals(1, vaultRepository.observations)
         val reopened = createViewModel()
         advanceUntilIdle()
         assertTrue(reopened.state.value.biometricEnabled)
@@ -156,7 +158,9 @@ class VaultAuthenticationTest {
         advanceUntilIdle()
 
         assertFalse(biometricEnabled)
-        assertEquals(VaultStage.HOW_TO_FIND_INFO, viewModel.state.value.stage)
+        assertEquals(VaultStage.UNLOCKED, viewModel.state.value.stage)
+        assertEquals(listOf(Video.sample), viewModel.state.value.hiddenVideos)
+        assertEquals(1, vaultRepository.observations)
         val reopened = createViewModel()
         advanceUntilIdle()
         reopened.onAction(VaultAction.BiometricAuthenticated)


### PR DESCRIPTION
Vault setup still displayed instructions for finding the vault even though it is directly accessible from More. History also rendered empty size and duration badges when metadata was unavailable.

- Finish vault setup directly in the gallery and first-time hiding in the media picker. Remove the obsolete dialog, states, actions, and translations.
- Hide unavailable size and duration badges, empty paths, and empty metadata rows in the shared video items. Preserve known metadata and display preferences in both history views.

## Verification

- `./gradlew assembleDebug test ktlintCheck --continue --console=plain` passed; 204 tests, zero failures, errors, or skips.
- Disposable Pixel 6a profile, API 37, arm64, 16 KB pages: direct vault setup, first-time hiding, and reopening the PIN-protected vault passed. Unit tests cover enabling and skipping biometric setup; the emulator had no enrolled biometrics.
- On the same device profile, verified history cards and list with unknown metadata, duration-only metadata, and a local video with known size, resolution, and duration. Empty badges disappeared and known values remained visible. Crash buffers were empty.

## Screenshots

| History view | Before | After |
| --- | --- | --- |
| List | <img src="https://raw.githubusercontent.com/anilbeesetti/nextplayer/181f844adadd0f163d9432763fc16ed6b90f1c7c/fastlane/metadata/android/en-US/images/0.18.0-fixes-review/history-list-before.png" width="220"> | <img src="https://raw.githubusercontent.com/anilbeesetti/nextplayer/181f844adadd0f163d9432763fc16ed6b90f1c7c/fastlane/metadata/android/en-US/images/0.18.0-fixes-review/history-list-after.png" width="220"> |
| Cards in More | <img src="https://raw.githubusercontent.com/anilbeesetti/nextplayer/181f844adadd0f163d9432763fc16ed6b90f1c7c/fastlane/metadata/android/en-US/images/0.18.0-fixes-review/history-cards-before.png" width="220"> | <img src="https://raw.githubusercontent.com/anilbeesetti/nextplayer/181f844adadd0f163d9432763fc16ed6b90f1c7c/fastlane/metadata/android/en-US/images/0.18.0-fixes-review/history-cards-after.png" width="220"> |

Vault setup now opens the [gallery directly](https://raw.githubusercontent.com/anilbeesetti/nextplayer/181f844adadd0f163d9432763fc16ed6b90f1c7c/fastlane/metadata/android/en-US/images/0.18.0-fixes-review/vault-setup-after.png), and first-time hiding returns to the [media picker](https://raw.githubusercontent.com/anilbeesetti/nextplayer/181f844adadd0f163d9432763fc16ed6b90f1c7c/fastlane/metadata/android/en-US/images/0.18.0-fixes-review/vault-hide-after.png).
