### PR TITLE
Add local audio selection for videos

### DIFF
--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/mappers/ToVideoState.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/mappers/ToVideoState.kt
@@ -12,6 +12,7 @@ fun MediumStateEntity.toVideoState(): VideoState {
         subtitleTrackIndex = subtitleTrackIndex,
         playbackSpeed = playbackSpeed,
         externalSubs = UriListConverter.fromStringToList(externalSubs),
+        externalAudio = UriListConverter.fromStringToList(externalAudio),
         videoScale = videoScale,
         subtitleDelayMilliseconds = subtitleDelayMilliseconds,
         subtitleSpeed = subtitleSpeed,

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/models/VideoState.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/models/VideoState.kt
@@ -9,6 +9,7 @@ data class VideoState(
     val subtitleTrackIndex: Int?,
     val playbackSpeed: Float?,
     val externalSubs: List<Uri>,
+    val externalAudio: List<Uri> = emptyList(),
     val videoScale: Float,
     val subtitleDelayMilliseconds: Long,
     val subtitleSpeed: Float,

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalMediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/LocalMediaRepository.kt
@@ -2,7 +2,6 @@ package dev.anilbeesetti.nextplayer.core.data.repository
 
 import android.content.Context
 import android.net.Uri
-import android.os.Environment
 import androidx.core.net.toUri
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dev.anilbeesetti.nextplayer.core.common.Utils
@@ -23,6 +22,8 @@ import dev.anilbeesetti.nextplayer.core.model.MediaInfo
 import dev.anilbeesetti.nextplayer.core.model.Video
 import io.github.anilbeesetti.nextlib.mediainfo.MediaInfoBuilder
 import java.util.Date
+import javax.inject.Inject
+import kotlin.math.absoluteValue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -30,8 +31,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
-import kotlin.math.absoluteValue
-import javax.inject.Inject
 
 class LocalMediaRepository @Inject constructor(
     private val mediumStateDao: MediumStateDao,
@@ -170,6 +169,15 @@ class LocalMediaRepository @Inject constructor(
             mediumState = stateEntity.copy(
                 videoScale = zoom,
             ),
+        )
+    }
+
+    override suspend fun addExternalAudioToMedium(uri: String, audioUri: Uri) {
+        val stateEntity = mediumStateDao.get(uri) ?: MediumStateEntity(uriString = uri)
+        val audio = UriListConverter.fromStringToList(stateEntity.externalAudio)
+        if (audioUri in audio) return
+        mediumStateDao.upsert(
+            stateEntity.copy(externalAudio = UriListConverter.fromListToString(audio + audioUri)),
         )
     }
 

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/MediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/MediaRepository.kt
@@ -60,6 +60,7 @@ interface MediaRepository {
     suspend fun updateMediumAudioTrack(uri: String, audioTrackIndex: Int)
     suspend fun updateMediumSubtitleTrack(uri: String, subtitleTrackIndex: Int)
     suspend fun updateMediumZoom(uri: String, zoom: Float)
+    suspend fun addExternalAudioToMedium(uri: String, audioUri: Uri)
     suspend fun addExternalSubtitleToMedium(uri: String, subtitleUri: Uri)
     suspend fun updateSubtitleDelay(uri: String, delay: Long)
     suspend fun updateSubtitleSpeed(uri: String, speed: Float)

--- a/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/fake/FakeMediaRepository.kt
+++ b/core/data/src/main/java/dev/anilbeesetti/nextplayer/core/data/repository/fake/FakeMediaRepository.kt
@@ -81,6 +81,9 @@ class FakeMediaRepository : MediaRepository {
     override suspend fun updateMediumZoom(uri: String, zoom: Float) {
     }
 
+    override suspend fun addExternalAudioToMedium(uri: String, audioUri: Uri) {
+    }
+
     override suspend fun addExternalSubtitleToMedium(uri: String, subtitleUri: Uri) {
     }
 

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {

--- a/core/database/schemas/dev.anilbeesetti.nextplayer.core.database.MediaDatabase/12.json
+++ b/core/database/schemas/dev.anilbeesetti.nextplayer.core.database.MediaDatabase/12.json
@@ -1,0 +1,417 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "a12ee9c7bbd05a1cf9b51dc82b65c0e5",
+    "entities": [
+      {
+        "tableName": "media_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uri` TEXT NOT NULL, `playback_position` INTEGER NOT NULL, `audio_track_index` INTEGER, `subtitle_track_index` INTEGER, `playback_speed` REAL, `last_played_time` INTEGER, `duration` INTEGER, `external_subs` TEXT NOT NULL, `external_audio` TEXT NOT NULL DEFAULT '', `video_scale` REAL NOT NULL, `subtitle_delay` INTEGER NOT NULL, `subtitle_speed` REAL NOT NULL, PRIMARY KEY(`uri`))",
+        "fields": [
+          {
+            "fieldPath": "uriString",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playbackPosition",
+            "columnName": "playback_position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "audioTrackIndex",
+            "columnName": "audio_track_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "subtitleTrackIndex",
+            "columnName": "subtitle_track_index",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playbackSpeed",
+            "columnName": "playback_speed",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "lastPlayedTime",
+            "columnName": "last_played_time",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "externalSubs",
+            "columnName": "external_subs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "externalAudio",
+            "columnName": "external_audio",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "videoScale",
+            "columnName": "video_scale",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitleDelayMilliseconds",
+            "columnName": "subtitle_delay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitleSpeed",
+            "columnName": "subtitle_speed",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_media_state_uri",
+            "unique": true,
+            "columnNames": [
+              "uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_media_state_uri` ON `${TABLE_NAME}` (`uri`)"
+          }
+        ]
+      },
+      {
+        "tableName": "hidden_video",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `vault_path` TEXT NOT NULL, `original_path` TEXT NOT NULL, `display_name` TEXT NOT NULL, `duration` INTEGER NOT NULL, `size` INTEGER NOT NULL, `width` INTEGER NOT NULL, `height` INTEGER NOT NULL, `hidden_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "vaultPath",
+            "columnName": "vault_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "originalPath",
+            "columnName": "original_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayName",
+            "columnName": "display_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "width",
+            "columnName": "width",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "height",
+            "columnName": "height",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hiddenAt",
+            "columnName": "hidden_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_hidden_video_vault_path",
+            "unique": true,
+            "columnNames": [
+              "vault_path"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_hidden_video_vault_path` ON `${TABLE_NAME}` (`vault_path`)"
+          }
+        ]
+      },
+      {
+        "tableName": "network_connection",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `protocol` TEXT NOT NULL, `host` TEXT NOT NULL, `port` INTEGER, `path` TEXT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `use_https` INTEGER NOT NULL, `authentication` TEXT NOT NULL DEFAULT 'PASSWORD', `private_key_file_name` TEXT NOT NULL DEFAULT '', `private_key_passphrase` TEXT NOT NULL DEFAULT '', `host_key_fingerprint` TEXT NOT NULL DEFAULT '', `created_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "protocol",
+            "columnName": "protocol",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "port",
+            "columnName": "port",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "useHttps",
+            "columnName": "use_https",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "authentication",
+            "columnName": "authentication",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'PASSWORD'"
+          },
+          {
+            "fieldPath": "privateKeyFileName",
+            "columnName": "private_key_file_name",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "privateKeyPassphrase",
+            "columnName": "private_key_passphrase",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "hostKeyFingerprint",
+            "columnName": "host_key_fingerprint",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `source` TEXT, `created_at` INTEGER NOT NULL, `last_refreshed_at` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastRefreshedAt",
+            "columnName": "last_refreshed_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist_item",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlist_id` INTEGER NOT NULL, `uri` TEXT NOT NULL, `position` INTEGER NOT NULL, `title` TEXT, `tvg_logo` TEXT, `duration` INTEGER NOT NULL, `group_title` TEXT, `last_played_at` INTEGER, PRIMARY KEY(`playlist_id`, `uri`), FOREIGN KEY(`playlist_id`) REFERENCES `playlist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlist_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tvgLogo",
+            "columnName": "tvg_logo",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupTitle",
+            "columnName": "group_title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "last_played_at",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlist_id",
+            "uri"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_item_playlist_id",
+            "unique": false,
+            "columnNames": [
+              "playlist_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_item_playlist_id` ON `${TABLE_NAME}` (`playlist_id`)"
+          },
+          {
+            "name": "index_playlist_item_playlist_id_position",
+            "unique": true,
+            "columnNames": [
+              "playlist_id",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_playlist_item_playlist_id_position` ON `${TABLE_NAME}` (`playlist_id`, `position`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlist_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a12ee9c7bbd05a1cf9b51dc82b65c0e5')"
+    ]
+  }
+}

--- a/core/database/src/androidTest/java/dev/anilbeesetti/nextplayer/core/database/MediaDatabaseMigrationTest.kt
+++ b/core/database/src/androidTest/java/dev/anilbeesetti/nextplayer/core/database/MediaDatabaseMigrationTest.kt
@@ -65,6 +65,26 @@ class MediaDatabaseMigrationTest {
         }
     }
 
+    @Test
+    fun migrate11To12_preservesPlaybackAndAddsEmptyAudio() {
+        helper.createDatabase("audio-migration", 11).apply {
+            execSQL(
+                "INSERT INTO media_state " +
+                    "(uri, playback_position, external_subs, video_scale, subtitle_delay, subtitle_speed) " +
+                    "VALUES ('content://video/one', 12345, 'file:///captions.srt', 1, 0, 1)",
+            )
+            close()
+        }
+        helper.runMigrationsAndValidate("audio-migration", 12, true, MediaDatabase.MIGRATION_11_12).use { db ->
+            db.query("SELECT playback_position, external_subs, external_audio FROM media_state").use { cursor ->
+                check(cursor.moveToFirst())
+                assertEquals(12345L, cursor.getLong(0))
+                assertEquals("file:///captions.srt", cursor.getString(1))
+                assertEquals("", cursor.getString(2))
+            }
+        }
+    }
+
     private companion object {
         const val TEST_DB = "migration-test"
     }

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/DatabaseModule.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/DatabaseModule.kt
@@ -33,6 +33,7 @@ object DatabaseModule {
             MediaDatabase.MIGRATION_8_9,
             MediaDatabase.MIGRATION_9_10,
             MediaDatabase.MIGRATION_10_11,
+            MediaDatabase.MIGRATION_11_12,
         )
         fallbackToDestructiveMigration(false)
     }.build()

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/MediaDatabase.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/MediaDatabase.kt
@@ -22,7 +22,7 @@ import dev.anilbeesetti.nextplayer.core.database.entities.PlaylistItemEntity
         PlaylistEntity::class,
         PlaylistItemEntity::class,
     ],
-    version = 11,
+    version = 12,
     exportSchema = true,
 )
 abstract class MediaDatabase : RoomDatabase() {
@@ -315,6 +315,12 @@ abstract class MediaDatabase : RoomDatabase() {
                     "ALTER TABLE `playlist_item` ADD COLUMN `duration` INTEGER NOT NULL DEFAULT -1",
                 )
                 db.execSQL("ALTER TABLE `playlist_item` ADD COLUMN `group_title` TEXT")
+            }
+        }
+
+        val MIGRATION_11_12 = object : Migration(11, 12) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `media_state` ADD COLUMN `external_audio` TEXT NOT NULL DEFAULT ''")
             }
         }
 

--- a/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/entities/MediumStateEntity.kt
+++ b/core/database/src/main/java/dev/anilbeesetti/nextplayer/core/database/entities/MediumStateEntity.kt
@@ -29,6 +29,8 @@ data class MediumStateEntity(
     val duration: Long? = null,
     @ColumnInfo(name = "external_subs")
     val externalSubs: String = "",
+    @ColumnInfo(name = "external_audio", defaultValue = "''")
+    val externalAudio: String = "",
     @ColumnInfo(name = "video_scale")
     val videoScale: Float = 1f,
     @ColumnInfo(name = "subtitle_delay")

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -206,6 +206,8 @@
     <string name="properties">Properties</string>
     <string name="volume_boost">Volume boost</string>
     <string name="volume_boost_desc">Boost audio volume up to 200%</string>
+    <string name="open_audio">Open local audio</string>
+    <string name="error_opening_audio">Can’t open this audio file</string>
     <string name="open_subtitle">Open local subtitle</string>
     <string name="no_subtitle_tracks_found">Subtitle tracks for this video are either unavailable or not supported.</string>
     <string name="no_audio_tracks_found">Audio tracks for this video are either unavailable or not supported.</string>

--- a/feature/player/build.gradle.kts
+++ b/feature/player/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {

--- a/feature/player/src/androidTest/java/dev/anilbeesetti/nextplayer/feature/player/service/ExternalAudioMediaSourceFactoryTest.kt
+++ b/feature/player/src/androidTest/java/dev/anilbeesetti/nextplayer/feature/player/service/ExternalAudioMediaSourceFactoryTest.kt
@@ -1,0 +1,90 @@
+package dev.anilbeesetti.nextplayer.feature.player.service
+
+import androidx.core.net.toUri
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import dev.anilbeesetti.nextplayer.feature.player.extensions.switchTrack
+import dev.anilbeesetti.nextplayer.feature.player.extensions.withExternalAudio
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@UnstableApi
+@RunWith(AndroidJUnit4::class)
+class ExternalAudioMediaSourceFactoryTest {
+    @Test
+    fun mergesSwitchableAudioWithoutShorteningPrimaryTimeline() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val context = instrumentation.targetContext
+        val primary = wav(File(context.cacheDir, "primary.wav"), 3)
+        val shortAudio = wav(File(context.cacheDir, "short.wav"), 1)
+        val longAudio = wav(File(context.cacheDir, "long.wav"), 5)
+        lateinit var player: ExoPlayer
+        try {
+            instrumentation.runOnMainSync {
+                player = ExoPlayer.Builder(context)
+                    .setMediaSourceFactory(ExternalAudioMediaSourceFactory(DefaultMediaSourceFactory(context)))
+                    .build()
+                player.setMediaItem(
+                    MediaItem.fromUri(primary.toUri()).withExternalAudio(listOf(shortAudio.toUri(), longAudio.toUri())),
+                )
+                player.prepare()
+            }
+            await { player.playbackState == Player.STATE_READY }
+            instrumentation.runOnMainSync {
+                assertEquals(3000L, player.duration)
+                assertEquals(3, player.currentTracks.groups.count { it.type == C.TRACK_TYPE_AUDIO })
+                player.switchTrack(C.TRACK_TYPE_AUDIO, 1)
+                player.setPlaybackSpeed(1.5f)
+                player.seekTo(2000)
+            }
+            await { player.currentTracks.groups[1].isSelected && player.playbackState == Player.STATE_READY }
+            instrumentation.runOnMainSync {
+                assertEquals(2000L, player.currentPosition)
+                assertEquals(1.5f, player.playbackParameters.speed)
+                assertTrue(!player.playWhenReady)
+                player.switchTrack(C.TRACK_TYPE_AUDIO, 0)
+            }
+            await { player.currentTracks.groups[0].isSelected }
+            instrumentation.runOnMainSync { player.switchTrack(C.TRACK_TYPE_AUDIO, -1) }
+            await { player.currentTracks.groups.none { it.isSelected } }
+        } finally {
+            instrumentation.runOnMainSync { player.release() }
+            listOf(primary, shortAudio, longAudio).forEach { it.delete() }
+        }
+    }
+
+    private fun await(condition: () -> Boolean) {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        repeat(100) {
+            var ready = false
+            instrumentation.runOnMainSync { ready = condition() }
+            if (ready) return
+            Thread.sleep(50)
+        }
+        throw AssertionError("Playback condition did not become true")
+    }
+
+    private fun wav(file: File, seconds: Int): File {
+        val bytes = seconds * 8000 * 2
+        val header = ByteBuffer.allocate(44).order(ByteOrder.LITTLE_ENDIAN)
+            .put("RIFF".toByteArray()).putInt(36 + bytes).put("WAVEfmt ".toByteArray())
+            .putInt(16).putShort(1).putShort(1).putInt(8000).putInt(16000)
+            .putShort(2).putShort(16).put("data".toByteArray()).putInt(bytes).array()
+        file.outputStream().use {
+            it.write(header)
+            it.write(ByteArray(bytes))
+        }
+        return file
+    }
+}

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/MediaPlayerScreen.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/MediaPlayerScreen.kt
@@ -125,6 +125,7 @@ fun MediaPlayerScreen(
     playerPreferences: PlayerPreferences,
     modifier: Modifier = Modifier,
     onSelectSubtitleClick: () -> Unit,
+    onSelectAudioClick: () -> Unit,
     onBackClick: () -> Unit,
     onPlayInBackgroundClick: () -> Unit,
 ) {
@@ -512,6 +513,7 @@ fun MediaPlayerScreen(
                 onVideoDecoderModeSelected = decoderState::switchVideoTo,
                 onAudioDecoderModeSelected = decoderState::switchAudioTo,
                 onSelectSubtitleClick = onSelectSubtitleClick,
+                onSelectAudioClick = onSelectAudioClick,
                 onSubtitleOptionEvent = viewModel::onSubtitleOptionEvent,
                 onVideoContentScaleChanged = { videoZoomAndContentScaleState.onVideoContentScaleChanged(it) },
             )

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerActivity.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/PlayerActivity.kt
@@ -8,6 +8,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
@@ -36,14 +37,16 @@ import dev.anilbeesetti.nextplayer.core.common.extensions.getInitialDirectoryUri
 import dev.anilbeesetti.nextplayer.core.common.extensions.getMediaContentUri
 import dev.anilbeesetti.nextplayer.core.common.service.registerForSuspendActivityResult
 import dev.anilbeesetti.nextplayer.core.data.repository.PlaylistRepository
+import dev.anilbeesetti.nextplayer.core.ui.R as coreUiR
 import dev.anilbeesetti.nextplayer.core.ui.theme.NextPlayerTheme
 import dev.anilbeesetti.nextplayer.feature.player.extensions.OpenDocumentAtInitialUri
 import dev.anilbeesetti.nextplayer.feature.player.extensions.setExtras
 import dev.anilbeesetti.nextplayer.feature.player.extensions.uriToSubtitleConfiguration
 import dev.anilbeesetti.nextplayer.feature.player.model.DecoderServiceState
-import dev.anilbeesetti.nextplayer.feature.player.service.decoderServiceState
 import dev.anilbeesetti.nextplayer.feature.player.service.PlayerService
+import dev.anilbeesetti.nextplayer.feature.player.service.addAudioTrack
 import dev.anilbeesetti.nextplayer.feature.player.service.addSubtitleTrack
+import dev.anilbeesetti.nextplayer.feature.player.service.decoderServiceState
 import dev.anilbeesetti.nextplayer.feature.player.service.stopPlayerSession
 import dev.anilbeesetti.nextplayer.feature.player.utils.PlayerApi
 import dev.anilbeesetti.nextplayer.feature.player.utils.PlaylistPlaybackContract
@@ -94,6 +97,8 @@ class PlayerActivity : ComponentActivity() {
      * Listeners
      */
     private val playbackStateListener: Player.Listener = playbackStateListener()
+
+    private val audioFileSuspendLauncher = registerForSuspendActivityResult(OpenDocumentAtInitialUri())
 
     private val subtitleFileSuspendLauncher = registerForSuspendActivityResult(OpenDocumentAtInitialUri())
 
@@ -151,6 +156,29 @@ class PlayerActivity : ComponentActivity() {
                                 controllerFuture?.await()?.addSubtitleTrack(uri)
                             }
                         },
+                        onSelectAudioClick = {
+                            lifecycleScope.launch {
+                                val videoUri = mediaController?.currentMediaItem?.localConfiguration?.uri
+                                val initialUri = videoUri?.let { video ->
+                                    withContext(Dispatchers.IO) { getInitialDirectoryUri(video) }
+                                }
+                                val uri = audioFileSuspendLauncher.launch(
+                                    OpenDocumentAtInitialUri.Input(
+                                        mimeTypes = arrayOf("audio/*", "application/ogg"),
+                                        initialUri = initialUri,
+                                    ),
+                                ) ?: return@launch
+                                try {
+                                    contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                    maybeInitControllerFuture()
+                                    if (controllerFuture?.await()?.addAudioTrack(uri) != true) {
+                                        Toast.makeText(this@PlayerActivity, coreUiR.string.error_opening_audio, Toast.LENGTH_LONG).show()
+                                    }
+                                } catch (_: SecurityException) {
+                                    Toast.makeText(this@PlayerActivity, coreUiR.string.error_opening_audio, Toast.LENGTH_LONG).show()
+                                }
+                            }
+                        },
                         onBackClick = { finishAndStopPlayerSession() },
                         onPlayInBackgroundClick = {
                             playInBackground = true
@@ -184,7 +212,7 @@ class PlayerActivity : ComponentActivity() {
             removeListener(playbackStateListener)
         }
         val shouldPlayInBackground = playInBackground || playerPreferences?.autoBackgroundPlay == true
-        if (subtitleFileSuspendLauncher.isAwaitingResult || !shouldPlayInBackground) {
+        if (subtitleFileSuspendLauncher.isAwaitingResult || audioFileSuspendLauncher.isAwaitingResult || !shouldPlayInBackground) {
             mediaController?.pause()
         }
 

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/MediaItem.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/MediaItem.kt
@@ -1,8 +1,24 @@
 package dev.anilbeesetti.nextplayer.feature.player.extensions
 
+import android.net.Uri
 import android.os.Bundle
+import androidx.core.net.toUri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+
+private const val MEDIA_METADATA_EXTERNAL_AUDIO_KEY = "external_audio"
+
+val MediaMetadata.externalAudio: List<Uri>
+    get() = extras?.getStringArrayList(MEDIA_METADATA_EXTERNAL_AUDIO_KEY)?.map { it.toUri() }.orEmpty()
+
+fun MediaItem.withExternalAudio(uris: List<Uri>): MediaItem = buildUpon()
+    .setMediaMetadata(
+        mediaMetadata.buildUpon().setExtras(
+            (mediaMetadata.extras?.let(::Bundle) ?: Bundle()).apply {
+                putStringArrayList(MEDIA_METADATA_EXTERNAL_AUDIO_KEY, ArrayList(uris.map { it.toString() }))
+            },
+        ).build(),
+    ).build()
 
 private const val MEDIA_METADATA_POSITION_KEY = "media_metadata_position"
 private const val MEDIA_METADATA_PLAYBACK_SPEED_KEY = "media_metadata_playback_speed"

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/TrackGroup.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/extensions/TrackGroup.kt
@@ -34,3 +34,8 @@ fun TrackGroup.getName(trackType: @C.TrackType Int, index: Int): String {
         }
     }
 }
+
+// Format IDs retain the merged source index when MediaSession rewrites TrackGroup IDs.
+@get:UnstableApi
+val TrackGroup.externalAudioIndex: Int?
+    get() = getFormat(0).id?.substringBefore(":")?.toIntOrNull()?.minus(1)?.takeIf { it >= 0 }

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/CustomCommands.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/CustomCommands.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.guava.await
 
 enum class CustomCommands(val customAction: String) {
     ADD_SUBTITLE_TRACK(customAction = "ADD_SUBTITLE_TRACK"),
+    ADD_AUDIO_TRACK(customAction = "ADD_AUDIO_TRACK"),
     SET_SKIP_SILENCE_ENABLED(customAction = "SET_SKIP_SILENCE_ENABLED"),
     GET_SKIP_SILENCE_ENABLED(customAction = "GET_SKIP_SILENCE_ENABLED"),
     SET_IS_SCRUBBING_MODE_ENABLED(customAction = "SET_IS_SCRUBBING_MODE_ENABLED"),
@@ -41,6 +42,7 @@ enum class CustomCommands(val customAction: String) {
             return entries.map { it.sessionCommand }
         }
 
+        const val AUDIO_TRACK_URI_KEY = "audio_track_uri"
         const val SUBTITLE_TRACK_URI_KEY = "subtitle_track_uri"
         const val SKIP_SILENCE_ENABLED_KEY = "skip_silence_enabled"
         const val IS_SCRUBBING_MODE_ENABLED_KEY = "is_scrubbing_mode_enabled"
@@ -54,6 +56,13 @@ enum class CustomCommands(val customAction: String) {
         const val DECODER_RECOVERY_TRACK_TYPE_KEY = "decoder_recovery_track_type"
         const val UNSUPPORTED_DECODER_MODE_KEY = "unsupported_decoder_mode"
     }
+}
+
+suspend fun MediaController.addAudioTrack(uri: Uri): Boolean {
+    val args = Bundle().apply {
+        putString(CustomCommands.AUDIO_TRACK_URI_KEY, uri.toString())
+    }
+    return sendCustomCommand(CustomCommands.ADD_AUDIO_TRACK.sessionCommand, args).await().resultCode == SessionResult.RESULT_SUCCESS
 }
 
 fun MediaController.addSubtitleTrack(uri: Uri) {

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/ExternalAudioMediaSourceFactory.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/ExternalAudioMediaSourceFactory.kt
@@ -1,0 +1,29 @@
+package dev.anilbeesetti.nextplayer.feature.player.service
+
+import androidx.media3.common.C
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.source.FilteringMediaSource
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.MergingMediaSource
+import dev.anilbeesetti.nextplayer.feature.player.extensions.externalAudio
+
+@UnstableApi
+internal class ExternalAudioMediaSourceFactory(
+    private val delegate: MediaSource.Factory,
+) : MediaSource.Factory by delegate {
+    override fun createMediaSource(mediaItem: MediaItem): MediaSource {
+        val video = delegate.createMediaSource(mediaItem)
+        val audio = mediaItem.mediaMetadata.externalAudio
+        if (audio.isEmpty()) return video
+        // Keep the video's duration even when a sidecar is shorter.
+        return MergingMediaSource(
+            true,
+            false,
+            video,
+            *audio.map { uri ->
+                FilteringMediaSource(delegate.createMediaSource(MediaItem.fromUri(uri)), C.TRACK_TYPE_AUDIO)
+            }.toTypedArray(),
+        )
+    }
+}

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/service/PlayerService.kt
@@ -22,8 +22,8 @@ import androidx.media3.common.Player.DISCONTINUITY_REASON_SEEK
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.ExoPlaybackException
+import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
@@ -58,6 +58,8 @@ import dev.anilbeesetti.nextplayer.feature.player.R
 import dev.anilbeesetti.nextplayer.feature.player.extensions.addAdditionalSubtitleConfiguration
 import dev.anilbeesetti.nextplayer.feature.player.extensions.audioTrackIndex
 import dev.anilbeesetti.nextplayer.feature.player.extensions.copy
+import dev.anilbeesetti.nextplayer.feature.player.extensions.externalAudio
+import dev.anilbeesetti.nextplayer.feature.player.extensions.externalAudioIndex
 import dev.anilbeesetti.nextplayer.feature.player.extensions.getManuallySelectedTrackIndex
 import dev.anilbeesetti.nextplayer.feature.player.extensions.playbackSpeed
 import dev.anilbeesetti.nextplayer.feature.player.extensions.positionMs
@@ -69,12 +71,14 @@ import dev.anilbeesetti.nextplayer.feature.player.extensions.subtitleTrackIndex
 import dev.anilbeesetti.nextplayer.feature.player.extensions.switchTrack
 import dev.anilbeesetti.nextplayer.feature.player.extensions.uriToSubtitleConfiguration
 import dev.anilbeesetti.nextplayer.feature.player.extensions.videoZoom
+import dev.anilbeesetti.nextplayer.feature.player.extensions.withExternalAudio
 import dev.anilbeesetti.nextplayer.feature.player.model.DecoderTrackType
 import io.github.anilbeesetti.nextlib.media3ext.ffdecoder.DecoderManager
 import io.github.anilbeesetti.nextlib.media3ext.ffdecoder.DecoderMode
 import io.github.anilbeesetti.nextlib.media3ext.ffdecoder.NextRenderersFactory
 import io.github.anilbeesetti.nextlib.media3ext.renderer.subtitleDelayMilliseconds
 import io.github.anilbeesetti.nextlib.media3ext.renderer.subtitleSpeed
+import io.github.anilbeesetti.nextlib.mediainfo.MediaInfoBuilder
 import java.io.File
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
@@ -117,6 +121,7 @@ class PlayerService : MediaSessionService() {
     private val customCommands = CustomCommands.asSessionCommands()
 
     private var isMediaItemReady = false
+    private var pendingAudioSelection: Pair<String, Uri>? = null
 
     private var loudnessEnhancer: LoudnessEnhancer? = null
     private var currentVolumeGain: Int = 0
@@ -280,8 +285,17 @@ class PlayerService : MediaSessionService() {
             if (!isMediaItemReady && tracks.groups.isNotEmpty()) {
                 isMediaItemReady = true
 
+                val player = mediaSession?.player ?: return
+                val pending = pendingAudioSelection
+                pendingAudioSelection = null
+                if (pending != null && pending.first == player.currentMediaItem?.mediaId) {
+                    val audioIndex = player.mediaMetadata.externalAudio.indexOf(pending.second)
+                    val trackIndex = tracks.groups.filter { it.type == C.TRACK_TYPE_AUDIO }
+                        .indexOfFirst { it.mediaTrackGroup.externalAudioIndex == audioIndex }
+                    if (audioIndex >= 0 && trackIndex >= 0) player.switchTrack(C.TRACK_TYPE_AUDIO, trackIndex)
+                }
                 if (!playerPreferences.rememberSelections) return
-                mediaSession?.player?.mediaMetadata?.audioTrackIndex?.let {
+                mediaSession?.player?.mediaMetadata?.audioTrackIndex?.takeIf { pending == null }?.let {
                     mediaSession?.player?.switchTrack(C.TRACK_TYPE_AUDIO, it)
                 }
                 mediaSession?.player?.mediaMetadata?.subtitleTrackIndex?.let {
@@ -351,7 +365,7 @@ class PlayerService : MediaSessionService() {
                 (
                     playbackState == Player.STATE_IDLE &&
                         player?.mediaItemCount == 0
-                )
+                    )
             if (shouldResetPlaybackParameters) {
                 mediaSession?.player?.trackSelectionParameters = TrackSelectionParameters.DEFAULT
                 mediaSession?.player?.setPlaybackSpeed(playerPreferences.defaultPlaybackSpeed)
@@ -395,7 +409,7 @@ class PlayerService : MediaSessionService() {
             // Update the media metadata duration so that it will be used later in position discontinuity handling
             player.replaceMediaItem(
                 player.currentMediaItemIndex,
-                currentMediaItem.copy(durationMs = player.duration.coerceAtLeast(0))
+                currentMediaItem.copy(durationMs = player.duration.coerceAtLeast(0)),
             )
 
             serviceScope.launch {
@@ -536,6 +550,43 @@ class PlayerService : MediaSessionService() {
                         )
                         player.addAdditionalSubtitleConfiguration(newSubConfiguration)
                     }
+                    return@future SessionResult(SessionResult.RESULT_SUCCESS)
+                }
+
+                CustomCommands.ADD_AUDIO_TRACK -> {
+                    val uri = args.getString(CustomCommands.AUDIO_TRACK_URI_KEY)?.toUri()
+                        ?.takeIf { it.scheme == ContentResolver.SCHEME_CONTENT || it.scheme == ContentResolver.SCHEME_FILE }
+                        ?: return@future SessionResult(SessionError.ERROR_BAD_VALUE)
+                    val player = session.player
+                    val mediaItem = player.currentMediaItem
+                        ?: return@future SessionResult(SessionError.ERROR_INVALID_STATE)
+                    val hasAudio = withContext(Dispatchers.IO) {
+                        runCatching {
+                            contentResolver.openFileDescriptor(uri, "r")?.use { descriptor ->
+                                MediaInfoBuilder().from(descriptor).build()?.let { info ->
+                                    try {
+                                        info.audioStreams.isNotEmpty()
+                                    } finally {
+                                        info.release()
+                                    }
+                                }
+                            } == true
+                        }.getOrDefault(false)
+                    }
+                    if (!hasAudio) return@future SessionResult(SessionError.ERROR_BAD_VALUE)
+                    if (player.currentMediaItem?.mediaId != mediaItem.mediaId) {
+                        return@future SessionResult(SessionError.ERROR_INVALID_STATE)
+                    }
+                    mediaRepository.addExternalAudioToMedium(mediaItem.mediaId, uri)
+                    val currentItem = player.currentMediaItem?.takeIf { it.mediaId == mediaItem.mediaId }
+                        ?: return@future SessionResult(SessionError.ERROR_INVALID_STATE)
+                    val audio = (currentItem.mediaMetadata.externalAudio + uri).distinct()
+                    pendingAudioSelection = currentItem.mediaId to uri
+                    val updatedItem = currentItem.withExternalAudio(audio).copy(positionMs = player.currentPosition)
+                    val index = player.currentMediaItemIndex
+                    player.addMediaItem(index + 1, updatedItem)
+                    player.seekTo(index + 1, player.currentPosition)
+                    player.removeMediaItem(index)
                     return@future SessionResult(SessionResult.RESULT_SUCCESS)
                 }
 
@@ -692,7 +743,9 @@ class PlayerService : MediaSessionService() {
             .setRenderersFactory(renderersFactory)
             .setTrackSelector(trackSelector)
             .setMediaSourceFactory(
-                DefaultMediaSourceFactory(applicationContext).setDataSourceFactory(dataSourceFactory),
+                ExternalAudioMediaSourceFactory(
+                    DefaultMediaSourceFactory(applicationContext).setDataSourceFactory(dataSourceFactory),
+                ),
             )
             .setAudioAttributes(
                 AudioAttributes.Builder()
@@ -785,6 +838,13 @@ class PlayerService : MediaSessionService() {
                 val videoState = mediaRepository.getVideoState(uri = mediaItem.mediaId)
 
                 val externalSubs = videoState?.externalSubs ?: emptyList()
+                val savedAudio = videoState?.externalAudio.orEmpty()
+                val externalAudio = withContext(Dispatchers.IO) {
+                    savedAudio.filter { uri ->
+                        runCatching { contentResolver.openAssetFileDescriptor(uri, "r")?.use { true } == true }
+                            .getOrDefault(false)
+                    }
+                }
                 val localSubs = if (!isNetwork) {
                     (videoState?.path ?: getPath(uri))?.let {
                         File(it).getLocalSubtitles(
@@ -792,7 +852,9 @@ class PlayerService : MediaSessionService() {
                             excludeSubsList = externalSubs,
                         )
                     } ?: emptyList()
-                } else emptyList()
+                } else {
+                    emptyList()
+                }
 
                 val existingSubConfigurations = mediaItem.localConfiguration?.subtitleConfigurations ?: emptyList()
                 val subConfigurations = (localSubs + externalSubs).map { subtitleUri ->
@@ -829,14 +891,14 @@ class PlayerService : MediaSessionService() {
                                 positionMs = positionMs,
                                 videoScale = videoScale,
                                 playbackSpeed = playbackSpeed,
-                                audioTrackIndex = audioTrackIndex,
+                                audioTrackIndex = audioTrackIndex.takeIf { externalAudio == savedAudio },
                                 subtitleTrackIndex = subtitleTrackIndex,
                                 subtitleDelayMilliseconds = subtitleDelay,
                                 subtitleSpeed = subtitleSpeed,
                             )
                         }.build(),
                     )
-                }.build()
+                }.build().withExternalAudio(externalAudio)
             }
         }.awaitAll()
     }

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/AudioTrackSelectorView.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/AudioTrackSelectorView.kt
@@ -3,20 +3,36 @@ package dev.anilbeesetti.nextplayer.feature.player.ui
 import androidx.annotation.OptIn
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import dev.anilbeesetti.nextplayer.core.common.extensions.getFilenameFromUri
 import dev.anilbeesetti.nextplayer.core.ui.R
+import dev.anilbeesetti.nextplayer.feature.player.extensions.externalAudio
+import dev.anilbeesetti.nextplayer.feature.player.extensions.externalAudioIndex
 import dev.anilbeesetti.nextplayer.feature.player.extensions.getName
 import dev.anilbeesetti.nextplayer.feature.player.state.rememberTracksState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @OptIn(UnstableApi::class)
 @Composable
@@ -24,9 +40,16 @@ fun BoxScope.AudioTrackSelectorView(
     modifier: Modifier = Modifier,
     show: Boolean,
     player: Player,
+    onSelectAudioClick: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     val audioTracksState = rememberTracksState(player, C.TRACK_TYPE_AUDIO)
+    val context = LocalContext.current
+    var audioNames by remember { mutableStateOf(emptyList<String>()) }
+    LaunchedEffect(player, audioTracksState.tracks) {
+        val uris = player.mediaMetadata.externalAudio
+        audioNames = withContext(Dispatchers.IO) { uris.map { context.getFilenameFromUri(it) } }
+    }
 
     OverlayView(
         modifier = modifier,
@@ -43,7 +66,9 @@ fun BoxScope.AudioTrackSelectorView(
             audioTracksState.tracks.forEachIndexed { index, track ->
                 RadioButtonRow(
                     selected = track.isSelected,
-                    text = track.mediaTrackGroup.getName(C.TRACK_TYPE_AUDIO, index),
+                    text = track.mediaTrackGroup.externalAudioIndex
+                        ?.let { audioNames.getOrNull(it) }
+                        ?: track.mediaTrackGroup.getName(C.TRACK_TYPE_AUDIO, index),
                     onClick = {
                         audioTracksState.switchTrack(index)
                         onDismiss()
@@ -58,6 +83,16 @@ fun BoxScope.AudioTrackSelectorView(
                     onDismiss()
                 },
             )
+            Spacer(modifier = Modifier.size(16.dp))
+            FilledTonalButton(
+                modifier = Modifier.fillMaxWidth(),
+                onClick = {
+                    onSelectAudioClick()
+                    onDismiss()
+                },
+            ) {
+                Text(text = stringResource(R.string.open_audio))
+            }
         }
     }
 }

--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/OverlayShowView.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/ui/OverlayShowView.kt
@@ -22,6 +22,7 @@ fun BoxScope.OverlayShowView(
     onVideoDecoderModeSelected: (DecoderMode) -> Unit = {},
     onAudioDecoderModeSelected: (DecoderMode) -> Unit = {},
     onSelectSubtitleClick: () -> Unit = {},
+    onSelectAudioClick: () -> Unit = {},
     onSubtitleOptionEvent: (SubtitleOptionsEvent) -> Unit = {},
     onVideoContentScaleChanged: (VideoContentScale) -> Unit = {},
 ) {
@@ -40,6 +41,7 @@ fun BoxScope.OverlayShowView(
     AudioTrackSelectorView(
         show = overlayView == OverlayView.AUDIO_SELECTOR,
         player = player,
+        onSelectAudioClick = onSelectAudioClick,
         onDismiss = onDismiss,
     )
 

--- a/feature/player/src/test/java/dev/anilbeesetti/nextplayer/feature/player/extensions/ExternalAudioTest.kt
+++ b/feature/player/src/test/java/dev/anilbeesetti/nextplayer/feature/player/extensions/ExternalAudioTest.kt
@@ -1,0 +1,45 @@
+package dev.anilbeesetti.nextplayer.feature.player.extensions
+
+import android.net.Uri
+import androidx.media3.common.Format
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.TrackGroup
+import androidx.media3.common.util.UnstableApi
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+@UnstableApi
+class ExternalAudioTest {
+    @Test
+    fun externalAudioIndexSurvivesSessionTrackGroupIds() {
+        val track = TrackGroup("session-id-1:0", Format.Builder().setId("1:0").build())
+        assertEquals(0, track.externalAudioIndex)
+    }
+
+    @Test
+    fun audioSurvivesMetadataAndSubtitleChanges() {
+        val audio = listOf(Uri.parse("content://documents/audio/one"), Uri.parse("file:///two.mp3"))
+        val subtitle = MediaItem.SubtitleConfiguration.Builder(Uri.parse("file:///captions.srt")).build()
+        val item = MediaItem.Builder()
+            .setUri("file:///video.mp4")
+            .setMediaId("video")
+            .setMediaMetadata(MediaMetadata.Builder().setTitle("Video").build())
+            .build()
+            .withExternalAudio(audio)
+            .copy(positionMs = 12000, audioTrackIndex = 2, playbackSpeed = 1.5f)
+            .buildUpon().setSubtitleConfigurations(listOf(subtitle)).build()
+
+        assertEquals(audio, item.mediaMetadata.externalAudio)
+        assertEquals(12000L, item.mediaMetadata.positionMs)
+        assertEquals(2, item.mediaMetadata.audioTrackIndex)
+        assertEquals("Video", item.mediaMetadata.title)
+        assertEquals(listOf(subtitle), item.localConfiguration!!.subtitleConfigurations)
+        assertEquals(emptyList<Uri>(), item.withExternalAudio(emptyList()).mediaMetadata.externalAudio)
+    }
+}


### PR DESCRIPTION
Add **Open local audio** to the audio-track sheet, matching the existing subtitle picker. Selected files become switchable tracks alongside embedded audio and are restored when the video is reopened.

The player merges audio-only sources with the video, selects the chosen track, and retains playback position and play/pause state. Document grants are used directly when validating audio; invalid files are rejected. Room migration 11 → 12 preserves existing playback history while adding saved audio attachments.

### Verification

- `./gradlew assembleDebug test ktlintCheck` — passed; **219 unit tests**, zero failures/errors.
- `./gradlew :feature:player:connectedDebugAndroidTest :core:database:connectedDebugAndroidTest` — **13 device tests passed** on a disposable **Pixel 6a, Android 16 / API 36, arm64-v8a**.
- Initial feature UI checks passed for MP3/M4A selection, automatic selection, filenames, duplicate prevention, disabling audio, switching to embedded audio, picker cancellation, invalid files, persistence after restart, preserved position/duration, and simultaneous external audio/subtitle playback.
- Playback regression coverage includes seeking beyond a shorter audio file's end, playback speed, and track switching.
- After merging `main` at `1082107a`: the two `KoinGraphTest` device tests and `LocalSubtitleTest` passed on the same disposable API 36 device. The latter now covers local audio together with subtitle reloads, decoder choices, playlist order, position, and play/pause state. Run with `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=dev.anilbeesetti.nextplayer.KoinGraphTest` and repeat with `dev.anilbeesetti.nextplayer.LocalSubtitleTest`.
- Repeated the MP3 document-picker flow after the merge: filename, automatic selection, three-minute duration, paused playback, and selected audio restoration after restart passed. No crashes; disposable emulator removed.
- Installed the tested debug build on the connected CPH2689 phone.

The merged build also explicitly declares the existing MediaInfo dependency and reads audio attachment extras from the media item so embedded playback metadata cannot hide filenames.

The repository's current `ktlintCheck` covers Gradle scripts but omits Android Kotlin source sets; changed Kotlin files were also checked directly with ktlint, except for the two-line callback wiring in `MediaPlayerScreen.kt`, whose pre-existing formatting was preserved.

### Screenshots

Before attaching a local file | After selecting local audio
:--: | :--:
![Before attaching local audio](https://github.com/anilbeesetti/nextplayer/blob/9edf93c2307211694398acb4f77df621d7fc791f/before.png?raw=true) | ![Local audio selected](https://github.com/anilbeesetti/nextplayer/blob/9edf93c2307211694398acb4f77df621d7fc791f/after.png?raw=true)

Captured from the initial feature build on a fresh disposable Pixel 6a / API 36 emulator.

Related: #1792.

