### PR TITLE
Add 100–200% volume boost using LoudnessEnhancer

### DIFF
--- a/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/utils/VolumeManager.kt
+++ b/feature/player/src/main/java/dev/anilbeesetti/nextplayer/feature/player/utils/VolumeManager.kt
@@ -22,10 +22,12 @@ class VolumeManager(private val audioManager: AudioManager) {
 
     var currentVolume = currentStreamVolume.toFloat()
         private set
-    val maxVolume get() = maxStreamVolume.times(loudnessEnhancer?.let { 2 } ?: 1)
+    val maxVolume get() = maxStreamVolume * 2
+
 
     val currentLoudnessGain get() = (currentVolume - maxStreamVolume) * (MAX_VOLUME_BOOST / maxStreamVolume)
-    val volumePercentage get() = (currentVolume / maxStreamVolume.toFloat()).times(100).toInt()
+    val volumePercentage get() = (currentVolume / maxVolume.toFloat()).times(100).toInt()
+
 
     @Suppress("DEPRECATION")
     fun setVolume(volume: Float, showVolumePanel: Boolean = false) {
@@ -57,6 +59,6 @@ class VolumeManager(private val audioManager: AudioManager) {
     }
 
     companion object {
-        const val MAX_VOLUME_BOOST = 2000
+        const val MAX_VOLUME_BOOST = 3000
     }
 }


### PR DESCRIPTION
## What this does
Extends volume control beyond the system maximum (100%) up to 200% using 
Android's `LoudnessEnhancer` audio effect API.

## Changes
- **VolumeManager.kt**
  - `maxVolume` doubled to represent the 0–200% range.
  - `setVolume()` now branches: 0–100% behaves as before (system stream 
    volume, `LoudnessEnhancer` disabled); 100–200% keeps system volume at 
    max and applies proportional gain via `LoudnessEnhancer` 
    (`MAX_VOLUME_BOOST = 3000`, i.e. +30 dB ceiling).
  - `volumePercentage` now calculated against the new doubled `maxVolume`.

- **PlayerService.kt**
  - Creates a `LoudnessEnhancer` instance tied to the player's audio 
    session when playback becomes ready; released and recreated safely 
    on each `STATE_READY` transition.
  - Releases the enhancer in `onDestroy()` to avoid leaking audio effects 
    across sessions.

- **PlayerActivity.kt**
  - Volume progress bar now reflects 0–200% instead of 0–100%.
  - Snaps to exactly 100% within a small resistance zone (±3%), so it's 
    easy to land back on normal volume.
  - Haptic feedback when snapping to 100%.
  - Progress bar color gradient from orange (100%) to red (200%) to 
    signal boosted volume.

## Why
Some content (voice-heavy videos, quiet recordings) is unusable at 100% 
system volume on certain devices. This lets users boost beyond that 
ceiling without needing a separate system-wide equalizer app.

## Testing
- Manually tested boost from 100–200%, snapping behavior at 100%, and 
  haptic feedback on Motorola Edge 50 Pro.
- Confirmed `LoudnessEnhancer` is released properly on player destroy 
  (no leaked audio effects across sessions).

## Notes
Open to feedback on the boost cap (200%/+30dB) and whether the color 
gradient should be configurable/toggleable.